### PR TITLE
Expand regenerate to rebuild missing metadata

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,26 +1,20 @@
 package main
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
-	"era/booru/ent"
-	"era/booru/internal/api"
-	"era/booru/internal/config"
-	"era/booru/internal/db"
-	minio "era/booru/internal/minio"
-	"era/booru/internal/processing"
-	"era/booru/internal/search"
-	"io"
-	"net/http"
-
-	mc "github.com/minio/minio-go/v7"
-
 	"log"
+	"net/http"
 	"os/signal"
 	"syscall"
 
 	"github.com/gin-gonic/gin"
+
+	"era/booru/internal/api"
+	"era/booru/internal/config"
+	"era/booru/internal/db"
+	"era/booru/internal/ingest"
+	minio "era/booru/internal/minio"
+	"era/booru/internal/search"
 )
 
 func main() {
@@ -52,10 +46,10 @@ func main() {
 
 	log.Println("Watching for new uploads")
 	go m.WatchPictures(ctx, func(ctx context.Context, object string) {
-		analyzeImage(m, ctx, database, object)
+		ingest.AnalyzeImage(ctx, m, database, object)
 	})
 	go m.WatchVideos(ctx, func(ctx context.Context, object string) {
-		analyzeVideo(cfg, m, ctx, database, object)
+		ingest.AnalyzeVideo(ctx, cfg, m, database, object)
 	})
 
 	r := gin.New()
@@ -69,86 +63,11 @@ func main() {
 
 	// Register API routes
 	api.RegisterMediaRoutes(r, database, m, cfg)
-	api.RegisterAdminRoutes(r, database, cfg)
+	api.RegisterAdminRoutes(r, database, m, cfg)
 	api.RegisterStaticRoutes(r)
 
 	log.Println("Starting Gin server on :8080")
 	r.Run(":8080")
 	log.Printf("Server running on :8080")
 
-}
-
-func analyzeImage(m *minio.Client, ctx context.Context, db *ent.Client, object string) {
-	rc, err := m.GetObject(ctx, m.Bucket, object, mc.GetObjectOptions{})
-	if err != nil {
-		log.Printf("get object %s: %v", object, err)
-		return
-	}
-	defer rc.Close()
-
-	data, err := io.ReadAll(rc)
-	if err != nil {
-		log.Printf("read object %s: %v", object, err)
-		return
-	}
-
-	metadata, err := processing.GetMetadata(data)
-	if err != nil {
-		log.Printf("get metadata for %s: %v", object, err)
-		return
-	}
-
-	if _, err := db.Media.Create().
-		SetID(object).
-		SetFormat(metadata.Format).
-		SetWidth(int16(metadata.Width)).
-		SetHeight(int16(metadata.Height)).
-		Save(ctx); err != nil {
-		log.Printf("create media: %v", err)
-	} else {
-		log.Printf("saved media %s", object)
-	}
-}
-
-func analyzeVideo(cfg *config.Config, m *minio.Client, ctx context.Context, db *ent.Client, object string) {
-	reqBody := struct {
-		Bucket string `json:"bucket"`
-		Key    string `json:"key"`
-	}{Bucket: m.Bucket, Key: object}
-
-	b, _ := json.Marshal(reqBody)
-	resp, err := http.Post(cfg.VideoWorkerURL+"/process", "application/json", bytes.NewReader(b))
-	if err != nil {
-		log.Printf("video worker request: %v", err)
-		return
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		log.Printf("video worker status: %s", resp.Status)
-		return
-	}
-	var out struct {
-		PreviewKey string `json:"preview_key"`
-		Format     string `json:"format"`
-		Width      int    `json:"width"`
-		Height     int    `json:"height"`
-		Duration   int    `json:"duration"`
-		Hash       string `json:"hash"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
-		log.Printf("decode video worker response: %v", err)
-		return
-	}
-
-	if _, err := db.Media.Create().
-		SetID(reqBody.Key).
-		SetFormat(out.Format).
-		SetWidth(int16(out.Width)).
-		SetHeight(int16(out.Height)).
-		SetDuration(int16(out.Duration)).
-		Save(ctx); err != nil {
-		log.Printf("create video media: %v", err)
-	} else {
-		log.Printf("saved video %s", object)
-	}
 }

--- a/internal/api/admin_handlers.go
+++ b/internal/api/admin_handlers.go
@@ -5,24 +5,54 @@ import (
 	"net/http"
 
 	"era/booru/ent"
+	"era/booru/ent/media"
 	"era/booru/internal/config"
+	"era/booru/internal/ingest"
+	minio "era/booru/internal/minio"
 	"era/booru/internal/search"
 
 	"github.com/gin-gonic/gin"
+	mc "github.com/minio/minio-go/v7"
 )
 
 // RegisterAdminRoutes registers admin-only endpoints.
-func RegisterAdminRoutes(r *gin.Engine, db *ent.Client, cfg *config.Config) {
-	r.POST("/api/admin/regenerate", regenerateHandler(db, cfg))
+func RegisterAdminRoutes(r *gin.Engine, db *ent.Client, m *minio.Client, cfg *config.Config) {
+	r.POST("/api/admin/regenerate", regenerateHandler(db, m, cfg))
 }
 
-func regenerateHandler(db *ent.Client, cfg *config.Config) gin.HandlerFunc {
+func regenerateHandler(db *ent.Client, m *minio.Client, cfg *config.Config) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		if err := search.Rebuild(c.Request.Context(), db, cfg.BlevePath); err != nil {
+		ctx := c.Request.Context()
+		if err := search.Rebuild(ctx, db, cfg.BlevePath); err != nil {
 			log.Printf("regenerate index: %v", err)
 			c.AbortWithStatus(http.StatusInternalServerError)
 			return
 		}
+		// Iterate over all objects in the bucket and regenerate missing metadata
+		for obj := range m.ListObjects(ctx, m.Bucket, mc.ListObjectsOptions{Recursive: true}) {
+			if obj.Err != nil {
+				log.Printf("list object %s: %v", obj.Key, obj.Err)
+				continue
+			}
+
+			exists, err := db.Media.Query().Where(media.IDEQ(obj.Key)).Exist(ctx)
+			if err != nil {
+				log.Printf("db check %s: %v", obj.Key, err)
+				continue
+			}
+			if exists {
+				continue
+			}
+
+			info, err := m.StatObject(ctx, m.Bucket, obj.Key, mc.StatObjectOptions{})
+			if err != nil {
+				log.Printf("stat object %s: %v", obj.Key, err)
+				continue
+			}
+
+			ingest.Process(ctx, cfg, m, db, obj.Key, info.ContentType)
+		}
+
 		c.Status(http.StatusOK)
 	}
 }

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -1,0 +1,126 @@
+package ingest
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+
+	"era/booru/ent"
+	"era/booru/internal/config"
+	"era/booru/internal/minio"
+	"era/booru/internal/processing"
+	mc "github.com/minio/minio-go/v7"
+)
+
+// AnalyzeImage extracts metadata from an image object and stores it in Postgres.
+func AnalyzeImage(ctx context.Context, m *minio.Client, db *ent.Client, object string) {
+	rc, err := m.GetObject(ctx, m.Bucket, object, mc.GetObjectOptions{})
+	if err != nil {
+		log.Printf("get object %s: %v", object, err)
+		return
+	}
+	defer rc.Close()
+
+	data, err := io.ReadAll(rc)
+	if err != nil {
+		log.Printf("read object %s: %v", object, err)
+		return
+	}
+
+	metadata, err := processing.GetMetadata(data)
+	if err != nil {
+		log.Printf("get metadata for %s: %v", object, err)
+		return
+	}
+
+	if _, err := db.Media.Create().
+		SetID(object).
+		SetFormat(metadata.Format).
+		SetWidth(int16(metadata.Width)).
+		SetHeight(int16(metadata.Height)).
+		Save(ctx); err != nil {
+		log.Printf("create media: %v", err)
+	} else {
+		log.Printf("saved media %s", object)
+	}
+}
+
+// AnalyzeVideo asks the video worker to create a preview and extract metadata
+// for the video object, then saves the metadata in Postgres.
+func AnalyzeVideo(ctx context.Context, cfg *config.Config, m *minio.Client, db *ent.Client, object string) {
+	reqBody := struct {
+		Bucket string `json:"bucket"`
+		Key    string `json:"key"`
+	}{Bucket: m.Bucket, Key: object}
+
+	b, _ := json.Marshal(reqBody)
+	resp, err := http.Post(cfg.VideoWorkerURL+"/process", "application/json", bytes.NewReader(b))
+	if err != nil {
+		log.Printf("video worker request: %v", err)
+		return
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		log.Printf("video worker status: %s", resp.Status)
+		return
+	}
+	var out struct {
+		PreviewKey string `json:"preview_key"`
+		Format     string `json:"format"`
+		Width      int    `json:"width"`
+		Height     int    `json:"height"`
+		Duration   int    `json:"duration"`
+		Hash       string `json:"hash"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		log.Printf("decode video worker response: %v", err)
+		return
+	}
+
+	if _, err := db.Media.Create().
+		SetID(reqBody.Key).
+		SetFormat(out.Format).
+		SetWidth(int16(out.Width)).
+		SetHeight(int16(out.Height)).
+		SetDuration(int16(out.Duration)).
+		Save(ctx); err != nil {
+		log.Printf("create video media: %v", err)
+	} else {
+		log.Printf("saved video %s", object)
+	}
+}
+
+// Process decides whether an object is an image or video and runs the
+// appropriate analysis functions. The contentType may be empty; in that case
+// the decision is made based on the file extension.
+func Process(ctx context.Context, cfg *config.Config, m *minio.Client, db *ent.Client, object, contentType string) {
+	if contentType != "" {
+		if strings.HasPrefix(contentType, "video/") {
+			AnalyzeVideo(ctx, cfg, m, db, object)
+			return
+		}
+		if strings.HasPrefix(contentType, "image/") {
+			AnalyzeImage(ctx, m, db, object)
+			return
+		}
+	}
+
+	ext := strings.ToLower(strings.TrimPrefix(pathExt(object), "."))
+	if config.SupportedVideoFormats[ext] {
+		AnalyzeVideo(ctx, cfg, m, db, object)
+		return
+	}
+	AnalyzeImage(ctx, m, db, object)
+}
+
+// pathExt is a tiny helper returning the file extension of a key.
+func pathExt(key string) string {
+	if i := strings.LastIndexByte(key, '.'); i != -1 {
+		return key[i:]
+	}
+	return ""
+}


### PR DESCRIPTION
## Summary
- share analyzeImage/analyzeVideo logic in new ingest package
- use ingest package from server and admin handler
- extend `/api/admin/regenerate` to iterate MinIO bucket and rebuild missing media records

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_685fc6d681d88320b19dbc42833c7b76