### PR TITLE
Add export tags endpoint

### DIFF
--- a/internal/api/admin_handlers.go
+++ b/internal/api/admin_handlers.go
@@ -74,8 +74,7 @@ func exportTagsHandler(db *ent.Client) gin.HandlerFunc {
 			return
 		}
 
-		c.Header("Content-Type", "application/x-ndjson")
-		c.Header("Content-Encoding", "gzip")
+		c.Header("Content-Type", "application/gzip")
 		c.Header("Content-Disposition", "attachment; filename=\"tags_export.ndjson.gz\"")
 
 		gz := gzip.NewWriter(c.Writer)
@@ -116,6 +115,7 @@ func importTagsHandler(db *ent.Client) gin.HandlerFunc {
 
 		gz, err := gzip.NewReader(c.Request.Body)
 		if err != nil {
+			log.Printf("gzip reader error: %v", err)
 			c.AbortWithStatus(http.StatusBadRequest)
 			return
 		}

--- a/internal/api/admin_handlers.go
+++ b/internal/api/admin_handlers.go
@@ -64,7 +64,7 @@ func regenerateHandler(db *ent.Client, m *minio.Client, cfg *config.Config) gin.
 func exportTagsHandler(db *ent.Client) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		ctx := c.Request.Context()
-		items, err := db.Media.Query().WithTags().All(ctx)
+		items, err := db.Media.Query().Where(media.HasTags()).WithTags().All(ctx)
 		if err != nil {
 			log.Printf("export tags: %v", err)
 			c.AbortWithStatus(http.StatusInternalServerError)
@@ -89,6 +89,9 @@ func exportTagsHandler(db *ent.Client) gin.HandlerFunc {
 		}
 
 		for _, m := range items {
+			if len(m.Edges.Tags) == 0 {
+				continue
+			}
 			tags := make([]string, len(m.Edges.Tags))
 			for i, t := range m.Edges.Tags {
 				tags[i] = t.Name

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -2,7 +2,6 @@ import type { MediaItem, MediaDetail } from './types/media';
 
 const apiBase = '/api';
 
-
 export interface MediaPreviewsResponse {
 	media: MediaItem[];
 	total: number;
@@ -68,4 +67,10 @@ export async function uploadToPresignedUrl(url: string, file: File): Promise<Res
 export async function regenerateReverseIndex(): Promise<void> {
 	const res = await fetch(`${apiBase}/admin/regenerate`, { method: 'POST' });
 	if (!res.ok) throw new Error(`HTTP ${res.status}`);
+}
+
+export async function downloadMediaTags(): Promise<Blob> {
+	const res = await fetch(`${apiBase}/admin/export-tags`);
+	if (!res.ok) throw new Error(`HTTP ${res.status}`);
+	return res.blob();
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -70,7 +70,19 @@ export async function regenerateReverseIndex(): Promise<void> {
 }
 
 export async function downloadMediaTags(): Promise<Blob> {
-	const res = await fetch(`${apiBase}/admin/export-tags`);
-	if (!res.ok) throw new Error(`HTTP ${res.status}`);
-	return res.blob();
+        const res = await fetch(`${apiBase}/admin/export-tags`);
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        return res.blob();
+}
+
+export async function importMediaTags(file: File): Promise<void> {
+       const res = await fetch(`${apiBase}/admin/import-tags`, {
+               method: 'POST',
+               headers: {
+                       'Content-Type': 'application/x-ndjson',
+                       'Content-Encoding': 'gzip'
+               },
+               body: file
+       });
+       if (!res.ok) throw new Error(`HTTP ${res.status}`);
 }

--- a/web/src/routes/settings/+page.svelte
+++ b/web/src/routes/settings/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import TabNav from '$lib/components/TabNav.svelte';
-	import { regenerateReverseIndex } from '$lib/api';
+	import { regenerateReverseIndex, downloadMediaTags } from '$lib/api';
 
 	async function regenerate() {
 		if (!confirm('Are you sure you want to regenerate the reverse index?')) {
@@ -13,9 +13,24 @@
 			alert(`Failed to regenerate: ${err}`);
 		}
 	}
+
+	async function exportTags() {
+		try {
+			const blob = await downloadMediaTags();
+			const url = URL.createObjectURL(blob);
+			const a = document.createElement('a');
+			a.href = url;
+			a.download = 'tags_export.ndjson.gz';
+			a.click();
+			URL.revokeObjectURL(url);
+		} catch (err) {
+			alert(`Failed to export: ${err}`);
+		}
+	}
 </script>
 
 <TabNav active="settings" />
-<div class="p-4">
+<div class="flex gap-2 p-4">
 	<button class="rounded border px-3 py-1" on:click={regenerate}> Regenerate reverse index </button>
+	<button class="rounded border px-3 py-1" on:click={exportTags}> Export tags </button>
 </div>

--- a/web/src/routes/settings/+page.svelte
+++ b/web/src/routes/settings/+page.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import TabNav from '$lib/components/TabNav.svelte';
-	import { regenerateReverseIndex, downloadMediaTags } from '$lib/api';
+	import { regenerateReverseIndex, downloadMediaTags, importMediaTags } from '$lib/api';
+
+	let fileInput: HTMLInputElement;
 
 	async function regenerate() {
 		if (!confirm('Are you sure you want to regenerate the reverse index?')) {
@@ -27,10 +29,25 @@
 			alert(`Failed to export: ${err}`);
 		}
 	}
+
+	async function importTags(event: Event) {
+		const input = event.target as HTMLInputElement;
+		const file = input.files && input.files[0];
+		if (!file) return;
+		try {
+			await importMediaTags(file);
+			alert('Import complete');
+		} catch (err) {
+			alert(`Failed to import: ${err}`);
+		}
+		input.value = '';
+	}
 </script>
 
 <TabNav active="settings" />
 <div class="flex gap-2 p-4">
 	<button class="rounded border px-3 py-1" on:click={regenerate}> Regenerate reverse index </button>
 	<button class="rounded border px-3 py-1" on:click={exportTags}> Export tags </button>
+	<button class="rounded border px-3 py-1" on:click={() => fileInput.click()}> Import tags </button>
+	<input type="file" bind:this={fileInput} accept=".gz" class="hidden" on:change={importTags} />
 </div>


### PR DESCRIPTION
## Summary
- provide endpoint to export media tags as gzipped NDJSON
- expose API from the web client
- add export button on settings page

## Testing
- `go vet ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68615227a288832091481ce65f58c261