### PR TITLE
Refactor upload_date as attribute

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -41,6 +41,10 @@ func main() {
 		log.Fatalf("connect db: %v", err)
 	}
 
+	if err := db.InitDefaultProperties(context.Background(), database); err != nil {
+		log.Fatalf("init default properties: %v", err)
+	}
+
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 

--- a/ent/hook/bleve.go
+++ b/ent/hook/bleve.go
@@ -47,7 +47,7 @@ func SyncBleve() ent.Hook {
 						return nil, err
 					}
 				}
-				if ierr := search.IndexMedia(mobj); ierr != nil {
+				if ierr := search.IndexMedia(ctx, mv.Client(), mobj); ierr != nil {
 					return nil, ierr
 				}
 			}

--- a/ent/media.go
+++ b/ent/media.go
@@ -6,7 +6,6 @@ import (
 	"era/booru/ent/media"
 	"fmt"
 	"strings"
-	"time"
 
 	"entgo.io/ent"
 	"entgo.io/ent/dialect/sql"
@@ -26,8 +25,6 @@ type Media struct {
 	Height int16 `json:"height,omitempty"`
 	// Duration in seconds for video or audio
 	Duration *int16 `json:"duration,omitempty"`
-	// Date when the file was uploaded
-	UploadDate *time.Time `json:"upload_date,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the MediaQuery when eager-loading is set.
 	Edges        MediaEdges `json:"edges"`
@@ -72,8 +69,6 @@ func (*Media) scanValues(columns []string) ([]any, error) {
 			values[i] = new(sql.NullInt64)
 		case media.FieldID, media.FieldFormat:
 			values[i] = new(sql.NullString)
-		case media.FieldUploadDate:
-			values[i] = new(sql.NullTime)
 		default:
 			values[i] = new(sql.UnknownType)
 		}
@@ -119,13 +114,6 @@ func (m *Media) assignValues(columns []string, values []any) error {
 			} else if value.Valid {
 				m.Duration = new(int16)
 				*m.Duration = int16(value.Int64)
-			}
-		case media.FieldUploadDate:
-			if value, ok := values[i].(*sql.NullTime); !ok {
-				return fmt.Errorf("unexpected type %T for field upload_date", values[i])
-			} else if value.Valid {
-				m.UploadDate = new(time.Time)
-				*m.UploadDate = value.Time
 			}
 		default:
 			m.selectValues.Set(columns[i], values[i])
@@ -185,11 +173,6 @@ func (m *Media) String() string {
 	if v := m.Duration; v != nil {
 		builder.WriteString("duration=")
 		builder.WriteString(fmt.Sprintf("%v", *v))
-	}
-	builder.WriteString(", ")
-	if v := m.UploadDate; v != nil {
-		builder.WriteString("upload_date=")
-		builder.WriteString(v.Format(time.ANSIC))
 	}
 	builder.WriteByte(')')
 	return builder.String()

--- a/ent/media/media.go
+++ b/ent/media/media.go
@@ -20,8 +20,6 @@ const (
 	FieldHeight = "height"
 	// FieldDuration holds the string denoting the duration field in the database.
 	FieldDuration = "duration"
-	// FieldUploadDate holds the string denoting the upload_date field in the database.
-	FieldUploadDate = "upload_date"
 	// EdgeTags holds the string denoting the tags edge name in mutations.
 	EdgeTags = "tags"
 	// EdgeMediaAttributes holds the string denoting the media_attributes edge name in mutations.
@@ -49,7 +47,6 @@ var Columns = []string{
 	FieldWidth,
 	FieldHeight,
 	FieldDuration,
-	FieldUploadDate,
 }
 
 var (
@@ -99,11 +96,6 @@ func ByHeight(opts ...sql.OrderTermOption) OrderOption {
 // ByDuration orders the results by the duration field.
 func ByDuration(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldDuration, opts...).ToFunc()
-}
-
-// ByUploadDate orders the results by the upload_date field.
-func ByUploadDate(opts ...sql.OrderTermOption) OrderOption {
-	return sql.OrderByField(FieldUploadDate, opts...).ToFunc()
 }
 
 // ByTagsCount orders the results by tags count.

--- a/ent/media/where.go
+++ b/ent/media/where.go
@@ -4,7 +4,6 @@ package media
 
 import (
 	"era/booru/ent/predicate"
-	"time"
 
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
@@ -83,11 +82,6 @@ func Height(v int16) predicate.Media {
 // Duration applies equality check predicate on the "duration" field. It's identical to DurationEQ.
 func Duration(v int16) predicate.Media {
 	return predicate.Media(sql.FieldEQ(FieldDuration, v))
-}
-
-// UploadDate applies equality check predicate on the "upload_date" field. It's identical to UploadDateEQ.
-func UploadDate(v time.Time) predicate.Media {
-	return predicate.Media(sql.FieldEQ(FieldUploadDate, v))
 }
 
 // FormatEQ applies the EQ predicate on the "format" field.
@@ -283,56 +277,6 @@ func DurationIsNil() predicate.Media {
 // DurationNotNil applies the NotNil predicate on the "duration" field.
 func DurationNotNil() predicate.Media {
 	return predicate.Media(sql.FieldNotNull(FieldDuration))
-}
-
-// UploadDateEQ applies the EQ predicate on the "upload_date" field.
-func UploadDateEQ(v time.Time) predicate.Media {
-	return predicate.Media(sql.FieldEQ(FieldUploadDate, v))
-}
-
-// UploadDateNEQ applies the NEQ predicate on the "upload_date" field.
-func UploadDateNEQ(v time.Time) predicate.Media {
-	return predicate.Media(sql.FieldNEQ(FieldUploadDate, v))
-}
-
-// UploadDateIn applies the In predicate on the "upload_date" field.
-func UploadDateIn(vs ...time.Time) predicate.Media {
-	return predicate.Media(sql.FieldIn(FieldUploadDate, vs...))
-}
-
-// UploadDateNotIn applies the NotIn predicate on the "upload_date" field.
-func UploadDateNotIn(vs ...time.Time) predicate.Media {
-	return predicate.Media(sql.FieldNotIn(FieldUploadDate, vs...))
-}
-
-// UploadDateGT applies the GT predicate on the "upload_date" field.
-func UploadDateGT(v time.Time) predicate.Media {
-	return predicate.Media(sql.FieldGT(FieldUploadDate, v))
-}
-
-// UploadDateGTE applies the GTE predicate on the "upload_date" field.
-func UploadDateGTE(v time.Time) predicate.Media {
-	return predicate.Media(sql.FieldGTE(FieldUploadDate, v))
-}
-
-// UploadDateLT applies the LT predicate on the "upload_date" field.
-func UploadDateLT(v time.Time) predicate.Media {
-	return predicate.Media(sql.FieldLT(FieldUploadDate, v))
-}
-
-// UploadDateLTE applies the LTE predicate on the "upload_date" field.
-func UploadDateLTE(v time.Time) predicate.Media {
-	return predicate.Media(sql.FieldLTE(FieldUploadDate, v))
-}
-
-// UploadDateIsNil applies the IsNil predicate on the "upload_date" field.
-func UploadDateIsNil() predicate.Media {
-	return predicate.Media(sql.FieldIsNull(FieldUploadDate))
-}
-
-// UploadDateNotNil applies the NotNil predicate on the "upload_date" field.
-func UploadDateNotNil() predicate.Media {
-	return predicate.Media(sql.FieldNotNull(FieldUploadDate))
 }
 
 // HasTags applies the HasEdge predicate on the "tags" edge.

--- a/ent/media_create.go
+++ b/ent/media_create.go
@@ -8,7 +8,6 @@ import (
 	"era/booru/ent/media"
 	"errors"
 	"fmt"
-	"time"
 
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
@@ -49,20 +48,6 @@ func (mc *MediaCreate) SetDuration(i int16) *MediaCreate {
 func (mc *MediaCreate) SetNillableDuration(i *int16) *MediaCreate {
 	if i != nil {
 		mc.SetDuration(*i)
-	}
-	return mc
-}
-
-// SetUploadDate sets the "upload_date" field.
-func (mc *MediaCreate) SetUploadDate(t time.Time) *MediaCreate {
-	mc.mutation.SetUploadDate(t)
-	return mc
-}
-
-// SetNillableUploadDate sets the "upload_date" field if the given value is not nil.
-func (mc *MediaCreate) SetNillableUploadDate(t *time.Time) *MediaCreate {
-	if t != nil {
-		mc.SetUploadDate(*t)
 	}
 	return mc
 }
@@ -186,10 +171,6 @@ func (mc *MediaCreate) createSpec() (*Media, *sqlgraph.CreateSpec) {
 	if value, ok := mc.mutation.Duration(); ok {
 		_spec.SetField(media.FieldDuration, field.TypeInt16, value)
 		_node.Duration = &value
-	}
-	if value, ok := mc.mutation.UploadDate(); ok {
-		_spec.SetField(media.FieldUploadDate, field.TypeTime, value)
-		_node.UploadDate = &value
 	}
 	if nodes := mc.mutation.TagsIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{

--- a/ent/media_update.go
+++ b/ent/media_update.go
@@ -9,7 +9,6 @@ import (
 	"era/booru/ent/predicate"
 	"errors"
 	"fmt"
-	"time"
 
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
@@ -53,26 +52,6 @@ func (mu *MediaUpdate) AddDuration(i int16) *MediaUpdate {
 // ClearDuration clears the value of the "duration" field.
 func (mu *MediaUpdate) ClearDuration() *MediaUpdate {
 	mu.mutation.ClearDuration()
-	return mu
-}
-
-// SetUploadDate sets the "upload_date" field.
-func (mu *MediaUpdate) SetUploadDate(t time.Time) *MediaUpdate {
-	mu.mutation.SetUploadDate(t)
-	return mu
-}
-
-// SetNillableUploadDate sets the "upload_date" field if the given value is not nil.
-func (mu *MediaUpdate) SetNillableUploadDate(t *time.Time) *MediaUpdate {
-	if t != nil {
-		mu.SetUploadDate(*t)
-	}
-	return mu
-}
-
-// ClearUploadDate clears the value of the "upload_date" field.
-func (mu *MediaUpdate) ClearUploadDate() *MediaUpdate {
-	mu.mutation.ClearUploadDate()
 	return mu
 }
 
@@ -161,12 +140,6 @@ func (mu *MediaUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	}
 	if mu.mutation.DurationCleared() {
 		_spec.ClearField(media.FieldDuration, field.TypeInt16)
-	}
-	if value, ok := mu.mutation.UploadDate(); ok {
-		_spec.SetField(media.FieldUploadDate, field.TypeTime, value)
-	}
-	if mu.mutation.UploadDateCleared() {
-		_spec.ClearField(media.FieldUploadDate, field.TypeTime)
 	}
 	if mu.mutation.TagsCleared() {
 		edge := &sqlgraph.EdgeSpec{
@@ -257,26 +230,6 @@ func (muo *MediaUpdateOne) AddDuration(i int16) *MediaUpdateOne {
 // ClearDuration clears the value of the "duration" field.
 func (muo *MediaUpdateOne) ClearDuration() *MediaUpdateOne {
 	muo.mutation.ClearDuration()
-	return muo
-}
-
-// SetUploadDate sets the "upload_date" field.
-func (muo *MediaUpdateOne) SetUploadDate(t time.Time) *MediaUpdateOne {
-	muo.mutation.SetUploadDate(t)
-	return muo
-}
-
-// SetNillableUploadDate sets the "upload_date" field if the given value is not nil.
-func (muo *MediaUpdateOne) SetNillableUploadDate(t *time.Time) *MediaUpdateOne {
-	if t != nil {
-		muo.SetUploadDate(*t)
-	}
-	return muo
-}
-
-// ClearUploadDate clears the value of the "upload_date" field.
-func (muo *MediaUpdateOne) ClearUploadDate() *MediaUpdateOne {
-	muo.mutation.ClearUploadDate()
 	return muo
 }
 
@@ -395,12 +348,6 @@ func (muo *MediaUpdateOne) sqlSave(ctx context.Context) (_node *Media, err error
 	}
 	if muo.mutation.DurationCleared() {
 		_spec.ClearField(media.FieldDuration, field.TypeInt16)
-	}
-	if value, ok := muo.mutation.UploadDate(); ok {
-		_spec.SetField(media.FieldUploadDate, field.TypeTime, value)
-	}
-	if muo.mutation.UploadDateCleared() {
-		_spec.ClearField(media.FieldUploadDate, field.TypeTime)
 	}
 	if muo.mutation.TagsCleared() {
 		edge := &sqlgraph.EdgeSpec{

--- a/ent/migrate/schema.go
+++ b/ent/migrate/schema.go
@@ -27,7 +27,6 @@ var (
 		{Name: "width", Type: field.TypeInt16},
 		{Name: "height", Type: field.TypeInt16},
 		{Name: "duration", Type: field.TypeInt16, Nullable: true},
-		{Name: "upload_date", Type: field.TypeTime, Nullable: true, SchemaType: map[string]string{"postgres": "date"}},
 	}
 	// MediaTable holds the schema information for the "media" table.
 	MediaTable = &schema.Table{

--- a/ent/mutation.go
+++ b/ent/mutation.go
@@ -11,7 +11,6 @@ import (
 	"errors"
 	"fmt"
 	"sync"
-	"time"
 
 	"entgo.io/ent"
 	"entgo.io/ent/dialect/sql"
@@ -523,7 +522,6 @@ type MediaMutation struct {
 	addheight     *int16
 	duration      *int16
 	addduration   *int16
-	upload_date   *time.Time
 	clearedFields map[string]struct{}
 	tags          map[int]struct{}
 	removedtags   map[int]struct{}
@@ -855,55 +853,6 @@ func (m *MediaMutation) ResetDuration() {
 	delete(m.clearedFields, media.FieldDuration)
 }
 
-// SetUploadDate sets the "upload_date" field.
-func (m *MediaMutation) SetUploadDate(t time.Time) {
-	m.upload_date = &t
-}
-
-// UploadDate returns the value of the "upload_date" field in the mutation.
-func (m *MediaMutation) UploadDate() (r time.Time, exists bool) {
-	v := m.upload_date
-	if v == nil {
-		return
-	}
-	return *v, true
-}
-
-// OldUploadDate returns the old "upload_date" field's value of the Media entity.
-// If the Media object wasn't provided to the builder, the object is fetched from the database.
-// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
-func (m *MediaMutation) OldUploadDate(ctx context.Context) (v *time.Time, err error) {
-	if !m.op.Is(OpUpdateOne) {
-		return v, errors.New("OldUploadDate is only allowed on UpdateOne operations")
-	}
-	if m.id == nil || m.oldValue == nil {
-		return v, errors.New("OldUploadDate requires an ID field in the mutation")
-	}
-	oldValue, err := m.oldValue(ctx)
-	if err != nil {
-		return v, fmt.Errorf("querying old value for OldUploadDate: %w", err)
-	}
-	return oldValue.UploadDate, nil
-}
-
-// ClearUploadDate clears the value of the "upload_date" field.
-func (m *MediaMutation) ClearUploadDate() {
-	m.upload_date = nil
-	m.clearedFields[media.FieldUploadDate] = struct{}{}
-}
-
-// UploadDateCleared returns if the "upload_date" field was cleared in this mutation.
-func (m *MediaMutation) UploadDateCleared() bool {
-	_, ok := m.clearedFields[media.FieldUploadDate]
-	return ok
-}
-
-// ResetUploadDate resets all changes to the "upload_date" field.
-func (m *MediaMutation) ResetUploadDate() {
-	m.upload_date = nil
-	delete(m.clearedFields, media.FieldUploadDate)
-}
-
 // AddTagIDs adds the "tags" edge to the Attribute entity by ids.
 func (m *MediaMutation) AddTagIDs(ids ...int) {
 	if m.tags == nil {
@@ -992,7 +941,7 @@ func (m *MediaMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *MediaMutation) Fields() []string {
-	fields := make([]string, 0, 5)
+	fields := make([]string, 0, 4)
 	if m.format != nil {
 		fields = append(fields, media.FieldFormat)
 	}
@@ -1004,9 +953,6 @@ func (m *MediaMutation) Fields() []string {
 	}
 	if m.duration != nil {
 		fields = append(fields, media.FieldDuration)
-	}
-	if m.upload_date != nil {
-		fields = append(fields, media.FieldUploadDate)
 	}
 	return fields
 }
@@ -1024,8 +970,6 @@ func (m *MediaMutation) Field(name string) (ent.Value, bool) {
 		return m.Height()
 	case media.FieldDuration:
 		return m.Duration()
-	case media.FieldUploadDate:
-		return m.UploadDate()
 	}
 	return nil, false
 }
@@ -1043,8 +987,6 @@ func (m *MediaMutation) OldField(ctx context.Context, name string) (ent.Value, e
 		return m.OldHeight(ctx)
 	case media.FieldDuration:
 		return m.OldDuration(ctx)
-	case media.FieldUploadDate:
-		return m.OldUploadDate(ctx)
 	}
 	return nil, fmt.Errorf("unknown Media field %s", name)
 }
@@ -1081,13 +1023,6 @@ func (m *MediaMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetDuration(v)
-		return nil
-	case media.FieldUploadDate:
-		v, ok := value.(time.Time)
-		if !ok {
-			return fmt.Errorf("unexpected type %T for field %s", value, name)
-		}
-		m.SetUploadDate(v)
 		return nil
 	}
 	return fmt.Errorf("unknown Media field %s", name)
@@ -1161,9 +1096,6 @@ func (m *MediaMutation) ClearedFields() []string {
 	if m.FieldCleared(media.FieldDuration) {
 		fields = append(fields, media.FieldDuration)
 	}
-	if m.FieldCleared(media.FieldUploadDate) {
-		fields = append(fields, media.FieldUploadDate)
-	}
 	return fields
 }
 
@@ -1180,9 +1112,6 @@ func (m *MediaMutation) ClearField(name string) error {
 	switch name {
 	case media.FieldDuration:
 		m.ClearDuration()
-		return nil
-	case media.FieldUploadDate:
-		m.ClearUploadDate()
 		return nil
 	}
 	return fmt.Errorf("unknown Media nullable field %s", name)
@@ -1203,9 +1132,6 @@ func (m *MediaMutation) ResetField(name string) error {
 		return nil
 	case media.FieldDuration:
 		m.ResetDuration()
-		return nil
-	case media.FieldUploadDate:
-		m.ResetUploadDate()
 		return nil
 	}
 	return fmt.Errorf("unknown Media field %s", name)

--- a/ent/schema/media.go
+++ b/ent/schema/media.go
@@ -2,7 +2,6 @@ package schema
 
 import (
 	"entgo.io/ent"
-	"entgo.io/ent/dialect"
 	"entgo.io/ent/schema/edge"
 	"entgo.io/ent/schema/field"
 )
@@ -33,11 +32,6 @@ func (Media) Fields() []ent.Field {
 			Optional().
 			Nillable().
 			Comment("Duration in seconds for video or audio"),
-		field.Time("upload_date").
-			Optional().
-			Nillable().
-			SchemaType(map[string]string{dialect.Postgres: "date"}).
-			Comment("Date when the file was uploaded"),
 	}
 }
 

--- a/internal/api/admin_handlers.go
+++ b/internal/api/admin_handlers.go
@@ -102,7 +102,7 @@ func exportTagsHandler(db *ent.Client) gin.HandlerFunc {
 			}
 
 			uploadDate := ""
-			if d, err := dbhelpers.GetUploadDate(ctx, db, m.ID); err == nil && d != nil {
+			if d, err := dbhelpers.GetDateProperty(ctx, db, m.ID, dbhelpers.UploadDatePropertyID); err == nil && d != nil {
 				uploadDate = d.Format("2006-01-02")
 			}
 
@@ -183,7 +183,7 @@ func importTagsHandler(db *ent.Client) gin.HandlerFunc {
 			if item.UploadDate != "" {
 				if t, err := time.Parse("2006-01-02", item.UploadDate); err == nil {
 					importDate = &t
-					currentDate, err := dbhelpers.GetUploadDate(ctx, db, item.ID)
+					currentDate, err := dbhelpers.GetDateProperty(ctx, db, item.ID, dbhelpers.UploadDatePropertyID)
 					if err == nil {
 						if currentDate == nil {
 							shouldUpdateDate = true
@@ -248,7 +248,7 @@ func importTagsHandler(db *ent.Client) gin.HandlerFunc {
 					return
 				}
 				if shouldUpdateDate && importDate != nil {
-					if err := dbhelpers.SetUploadDate(ctx, db, item.ID, *importDate); err != nil {
+					if err := dbhelpers.SetDateProperty(ctx, db, item.ID, dbhelpers.UploadDatePropertyID, *importDate); err != nil {
 						log.Printf("set upload date for %s: %v", item.ID, err)
 						c.AbortWithStatus(http.StatusInternalServerError)
 						return

--- a/internal/api/media_handlers.go
+++ b/internal/api/media_handlers.go
@@ -72,12 +72,12 @@ func listCommon(minioPrefix string, videoBucket string, pictureBucket string) gi
 
 			url := fmt.Sprintf("%s/%s/%s", minioPrefix, bucket, key)
 			out[i] = gin.H{
-				"id":          mitem.ID,
-				"url":         url,
-				"width":       mitem.Width,
-				"height":      mitem.Height,
-				"format":      mitem.Format,
-				"upload_date": mitem.UploadDate,
+				"id":         mitem.ID,
+				"url":        url,
+				"width":      mitem.Width,
+				"height":     mitem.Height,
+				"format":     mitem.Format,
+				"properties": mitem.Properties,
 			}
 		}
 		c.JSON(http.StatusOK, gin.H{"media": out, "total": total})
@@ -110,17 +110,17 @@ func getMediaHandler(db *ent.Client, m *minio.Client, cfg *config.Config) gin.Ha
 		for i, t := range item.Edges.Tags {
 			tags[i] = t.Name
 		}
-		date, _ := dbhelpers.GetDateProperty(c.Request.Context(), db, item.ID, dbhelpers.UploadDatePropertyID)
+		props, _ := dbhelpers.ListProperties(c.Request.Context(), db, item.ID)
 		c.JSON(http.StatusOK, gin.H{
-			"id":          item.ID,
-			"url":         url,
-			"width":       item.Width,
-			"height":      item.Height,
-			"format":      item.Format,
-			"duration":    item.Duration,
-			"upload_date": date,
-			"size":        stat.Size,
-			"tags":        tags,
+			"id":         item.ID,
+			"url":        url,
+			"width":      item.Width,
+			"height":     item.Height,
+			"format":     item.Format,
+			"duration":   item.Duration,
+			"size":       stat.Size,
+			"tags":       tags,
+			"properties": props,
 		})
 	}
 }

--- a/internal/api/media_handlers.go
+++ b/internal/api/media_handlers.go
@@ -10,7 +10,7 @@ import (
 	"era/booru/ent"
 	"era/booru/ent/media"
 	"era/booru/internal/config"
-	"era/booru/internal/db"
+	dbhelpers "era/booru/internal/db"
 	"era/booru/internal/minio"
 	"era/booru/internal/search"
 
@@ -110,6 +110,7 @@ func getMediaHandler(db *ent.Client, m *minio.Client, cfg *config.Config) gin.Ha
 		for i, t := range item.Edges.Tags {
 			tags[i] = t.Name
 		}
+		date, _ := dbhelpers.GetUploadDate(c.Request.Context(), db, item.ID)
 		c.JSON(http.StatusOK, gin.H{
 			"id":          item.ID,
 			"url":         url,
@@ -117,7 +118,7 @@ func getMediaHandler(db *ent.Client, m *minio.Client, cfg *config.Config) gin.Ha
 			"height":      item.Height,
 			"format":      item.Format,
 			"duration":    item.Duration,
-			"upload_date": item.UploadDate,
+			"upload_date": date,
 			"size":        stat.Size,
 			"tags":        tags,
 		})
@@ -162,7 +163,7 @@ func updateMediaTagsHandler(dbClient *ent.Client) gin.HandlerFunc {
 
 		clean := normalizeTags(body.Tags)
 
-		tagIDs, err := db.FindOrCreateTags(c.Request.Context(), dbClient, clean)
+               tagIDs, err := dbhelpers.FindOrCreateTags(c.Request.Context(), dbClient, clean)
 		if err != nil {
 			log.Printf("error handling tags: %v", err)
 			c.AbortWithStatus(http.StatusInternalServerError)

--- a/internal/api/media_handlers.go
+++ b/internal/api/media_handlers.go
@@ -110,7 +110,7 @@ func getMediaHandler(db *ent.Client, m *minio.Client, cfg *config.Config) gin.Ha
 		for i, t := range item.Edges.Tags {
 			tags[i] = t.Name
 		}
-		date, _ := dbhelpers.GetUploadDate(c.Request.Context(), db, item.ID)
+		date, _ := dbhelpers.GetDateProperty(c.Request.Context(), db, item.ID, dbhelpers.UploadDatePropertyID)
 		c.JSON(http.StatusOK, gin.H{
 			"id":          item.ID,
 			"url":         url,
@@ -163,7 +163,7 @@ func updateMediaTagsHandler(dbClient *ent.Client) gin.HandlerFunc {
 
 		clean := normalizeTags(body.Tags)
 
-               tagIDs, err := dbhelpers.FindOrCreateTags(c.Request.Context(), dbClient, clean)
+		tagIDs, err := dbhelpers.FindOrCreateTags(c.Request.Context(), dbClient, clean)
 		if err != nil {
 			log.Printf("error handling tags: %v", err)
 			c.AbortWithStatus(http.StatusInternalServerError)

--- a/internal/db/attribute_helpers.go
+++ b/internal/db/attribute_helpers.go
@@ -40,21 +40,17 @@ func FindOrCreateProperty(ctx context.Context, db *ent.Client, name string, typ 
 	return at, err
 }
 
-// SetUploadDate stores the upload date value as a date property on the media item.
-func SetUploadDate(ctx context.Context, db *ent.Client, mediaID string, t time.Time) error {
-	prop, err := FindOrCreateProperty(ctx, db, "Upload Date", attribute.TypeDate)
-	if err != nil {
-		return err
-	}
+// SetDateProperty stores a date property value on the media item.
+func SetDateProperty(ctx context.Context, db *ent.Client, mediaID string, attrID int, t time.Time) error {
 	val := t.Format("2006-01-02")
 	ma, err := db.MediaAttribute.Query().
 		Where(mediaattribute.MediaIDEQ(mediaID)).
-		Where(mediaattribute.AttributeIDEQ(prop.ID)).
+		Where(mediaattribute.AttributeIDEQ(attrID)).
 		Only(ctx)
 	if ent.IsNotFound(err) {
 		_, err = db.MediaAttribute.Create().
 			SetMediaID(mediaID).
-			SetAttributeID(prop.ID).
+			SetAttributeID(attrID).
 			SetValue(val).
 			Save(ctx)
 		return err
@@ -66,18 +62,11 @@ func SetUploadDate(ctx context.Context, db *ent.Client, mediaID string, t time.T
 	return err
 }
 
-// GetUploadDate retrieves the upload date property for a media item.
-func GetUploadDate(ctx context.Context, db *ent.Client, mediaID string) (*time.Time, error) {
-	prop, err := db.Attribute.Query().Where(attribute.NameEQ("Upload Date")).Only(ctx)
-	if ent.IsNotFound(err) {
-		return nil, nil
-	}
-	if err != nil {
-		return nil, err
-	}
+// GetDateProperty retrieves the date property for a media item.
+func GetDateProperty(ctx context.Context, db *ent.Client, mediaID string, attrID int) (*time.Time, error) {
 	ma, err := db.MediaAttribute.Query().
 		Where(mediaattribute.MediaIDEQ(mediaID)).
-		Where(mediaattribute.AttributeIDEQ(prop.ID)).
+		Where(mediaattribute.AttributeIDEQ(attrID)).
 		Only(ctx)
 	if ent.IsNotFound(err) {
 		return nil, nil

--- a/internal/db/attribute_helpers.go
+++ b/internal/db/attribute_helpers.go
@@ -3,9 +3,11 @@ package db
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"era/booru/ent"
 	"era/booru/ent/attribute"
+	"era/booru/ent/mediaattribute"
 )
 
 func FindOrCreateTag(ctx context.Context, db *ent.Client, name string) (*ent.Attribute, error) {
@@ -27,4 +29,68 @@ func FindOrCreateTags(ctx context.Context, db *ent.Client, tagNames []string) ([
 		tagIDs = append(tagIDs, tg.ID)
 	}
 	return tagIDs, nil
+}
+
+// FindOrCreateProperty looks up an attribute by name and type, creating it if needed.
+func FindOrCreateProperty(ctx context.Context, db *ent.Client, name string, typ attribute.Type) (*ent.Attribute, error) {
+	at, err := db.Attribute.Query().Where(attribute.NameEQ(name)).Only(ctx)
+	if ent.IsNotFound(err) {
+		at, err = db.Attribute.Create().SetName(name).SetType(typ).Save(ctx)
+	}
+	return at, err
+}
+
+// SetUploadDate stores the upload date value as a date property on the media item.
+func SetUploadDate(ctx context.Context, db *ent.Client, mediaID string, t time.Time) error {
+	prop, err := FindOrCreateProperty(ctx, db, "Upload Date", attribute.TypeDate)
+	if err != nil {
+		return err
+	}
+	val := t.Format("2006-01-02")
+	ma, err := db.MediaAttribute.Query().
+		Where(mediaattribute.MediaIDEQ(mediaID)).
+		Where(mediaattribute.AttributeIDEQ(prop.ID)).
+		Only(ctx)
+	if ent.IsNotFound(err) {
+		_, err = db.MediaAttribute.Create().
+			SetMediaID(mediaID).
+			SetAttributeID(prop.ID).
+			SetValue(val).
+			Save(ctx)
+		return err
+	}
+	if err != nil {
+		return err
+	}
+	_, err = ma.Update().SetValue(val).Save(ctx)
+	return err
+}
+
+// GetUploadDate retrieves the upload date property for a media item.
+func GetUploadDate(ctx context.Context, db *ent.Client, mediaID string) (*time.Time, error) {
+	prop, err := db.Attribute.Query().Where(attribute.NameEQ("Upload Date")).Only(ctx)
+	if ent.IsNotFound(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	ma, err := db.MediaAttribute.Query().
+		Where(mediaattribute.MediaIDEQ(mediaID)).
+		Where(mediaattribute.AttributeIDEQ(prop.ID)).
+		Only(ctx)
+	if ent.IsNotFound(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	if ma.Value == nil {
+		return nil, nil
+	}
+	parsed, err := time.Parse("2006-01-02", *ma.Value)
+	if err != nil {
+		return nil, err
+	}
+	return &parsed, nil
 }

--- a/internal/db/default_properties.go
+++ b/internal/db/default_properties.go
@@ -5,7 +5,6 @@ import (
 
 	"era/booru/ent"
 	"era/booru/ent/attribute"
-	"era/booru/internal/search"
 )
 
 var UploadDatePropertyID int
@@ -17,6 +16,5 @@ func InitDefaultProperties(ctx context.Context, db *ent.Client) error {
 		return err
 	}
 	UploadDatePropertyID = prop.ID
-	search.SetUploadDatePropertyID(prop.ID)
 	return nil
 }

--- a/internal/db/default_properties.go
+++ b/internal/db/default_properties.go
@@ -1,0 +1,22 @@
+package db
+
+import (
+	"context"
+
+	"era/booru/ent"
+	"era/booru/ent/attribute"
+	"era/booru/internal/search"
+)
+
+var UploadDatePropertyID int
+
+// InitDefaultProperties ensures built-in properties exist and caches their IDs.
+func InitDefaultProperties(ctx context.Context, db *ent.Client) error {
+	prop, err := FindOrCreateProperty(ctx, db, "Upload Date", attribute.TypeDate)
+	if err != nil {
+		return err
+	}
+	UploadDatePropertyID = prop.ID
+	search.SetUploadDatePropertyID(prop.ID)
+	return nil
+}

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -13,6 +13,7 @@ import (
 
 	"era/booru/ent"
 	"era/booru/internal/config"
+	dbhelpers "era/booru/internal/db"
 	"era/booru/internal/minio"
 	"era/booru/internal/processing"
 
@@ -45,11 +46,14 @@ func AnalyzeImage(ctx context.Context, m *minio.Client, db *ent.Client, object s
 		SetFormat(metadata.Format).
 		SetWidth(int16(metadata.Width)).
 		SetHeight(int16(metadata.Height)).
-		SetUploadDate(time.Now().UTC()).
 		Save(ctx)
 	if err != nil {
 		log.Printf("create media: %v", err)
 		return "", err
+	}
+
+	if err := dbhelpers.SetUploadDate(ctx, db, media.ID, time.Now().UTC()); err != nil {
+		log.Printf("set upload date: %v", err)
 	}
 
 	log.Printf("saved media %s", object)
@@ -96,11 +100,14 @@ func AnalyzeVideo(ctx context.Context, cfg *config.Config, m *minio.Client, db *
 		SetWidth(int16(out.Width)).
 		SetHeight(int16(out.Height)).
 		SetDuration(int16(out.Duration)).
-		SetUploadDate(time.Now().UTC()).
 		Save(ctx)
 	if err != nil {
 		log.Printf("create video media: %v", err)
 		return "", err
+	}
+
+	if err := dbhelpers.SetUploadDate(ctx, db, media.ID, time.Now().UTC()); err != nil {
+		log.Printf("set upload date: %v", err)
 	}
 
 	log.Printf("saved video %s", object)

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -52,7 +52,7 @@ func AnalyzeImage(ctx context.Context, m *minio.Client, db *ent.Client, object s
 		return "", err
 	}
 
-	if err := dbhelpers.SetUploadDate(ctx, db, media.ID, time.Now().UTC()); err != nil {
+	if err := dbhelpers.SetDateProperty(ctx, db, media.ID, dbhelpers.UploadDatePropertyID, time.Now().UTC()); err != nil {
 		log.Printf("set upload date: %v", err)
 	}
 
@@ -106,7 +106,7 @@ func AnalyzeVideo(ctx context.Context, cfg *config.Config, m *minio.Client, db *
 		return "", err
 	}
 
-	if err := dbhelpers.SetUploadDate(ctx, db, media.ID, time.Now().UTC()); err != nil {
+	if err := dbhelpers.SetDateProperty(ctx, db, media.ID, dbhelpers.UploadDatePropertyID, time.Now().UTC()); err != nil {
 		log.Printf("set upload date: %v", err)
 	}
 

--- a/internal/search/index.go
+++ b/internal/search/index.go
@@ -11,12 +11,19 @@ import (
 	"time"
 
 	"era/booru/ent"
-	"era/booru/ent/attribute"
 	"era/booru/ent/mediaattribute"
 
 	"github.com/blevesearch/bleve/v2"
 	q "github.com/blevesearch/bleve/v2/search/query"
 )
+
+// uploadDatePropertyID holds the attribute ID for the built-in upload date property.
+var uploadDatePropertyID int
+
+// SetUploadDatePropertyID configures the package with the ID of the upload date property.
+func SetUploadDatePropertyID(id int) {
+	uploadDatePropertyID = id
+}
 
 // parseQuery turns a string like "width>300 type=image" into a Bleve query.
 // Numeric fields support range comparisons (> < >= <= =) while string fields
@@ -147,7 +154,7 @@ func IndexMedia(ctx context.Context, db *ent.Client, m *ent.Media) error {
 	var uploadDate *time.Time
 	ma, err := db.MediaAttribute.Query().
 		Where(mediaattribute.MediaIDEQ(m.ID)).
-		Where(mediaattribute.HasAttributeWith(attribute.NameEQ("Upload Date"))).
+		Where(mediaattribute.AttributeIDEQ(uploadDatePropertyID)).
 		Only(ctx)
 	if err == nil && ma.Value != nil {
 		if t, err2 := time.Parse("2006-01-02", *ma.Value); err2 == nil {

--- a/web/src/lib/types/media.ts
+++ b/web/src/lib/types/media.ts
@@ -1,10 +1,16 @@
+export interface Property {
+       name: string;
+       type: string;
+       value: string;
+}
+
 export interface MediaItem {
-	id: string;
-	url: string;
-	width: number;
-	height: number;
-	format: string;
-	upload_date: Date;
+       id: string;
+       url: string;
+       width: number;
+       height: number;
+       format: string;
+       properties: Property[];
 }
 
 export interface MediaDetail extends MediaItem {

--- a/web/src/routes/media/[id]/+page.svelte
+++ b/web/src/routes/media/[id]/+page.svelte
@@ -4,17 +4,19 @@
 	import { goto } from '$app/navigation';
 	import TabNav from '$lib/components/TabNav.svelte';
 	import { fetchMediaDetail, deleteMedia, updateMediaTags } from '$lib/api';
-	import type { MediaDetail } from '$lib/types/media';
+import type { MediaDetail } from '$lib/types/media';
 
-	let media: MediaDetail | null = null;
+let media: MediaDetail | null = null;
+let uploadDate: string | null = null;
 	let tagsInput = '';
 	let edit = false;
 
 	onMount(async () => {
 		const id = page.params.id;
-		try {
-			media = await fetchMediaDetail(id);
-			tagsInput = media?.tags.map((t) => t.replace(/ /g, '_')).join(' ') ?? '';
+                try {
+                        media = await fetchMediaDetail(id);
+                        uploadDate = media?.properties.find((p) => p.name === 'Upload Date')?.value ?? null;
+                        tagsInput = media?.tags.map((t) => t.replace(/ /g, '_')).join(' ') ?? '';
 		} catch (err) {
 			console.error('failed to load media', err);
 		}
@@ -56,7 +58,9 @@
 				<p>Format: {media.format}</p>
 				<p>Dimensions: {media.width}×{media.height}</p>
 				<p>Size: {(media.size / 1024 / 1024).toFixed(2)} MB</p>
-				<p>Uploaded: {new Date(media.upload_date).toLocaleDateString(undefined, { day: '2-digit', month: 'short', year: 'numeric' })}</p>
+                               {#if uploadDate}
+                                       <p>Uploaded: {new Date(uploadDate).toLocaleDateString(undefined, { day: '2-digit', month: 'short', year: 'numeric' })}</p>
+                               {/if}
 			</div>
 			{#if media.tags.length}
 				<div class="text-sm">


### PR DESCRIPTION
## Summary
- move upload_date from Media schema into attribute system
- add helpers to get/set Upload Date property
- adjust ingestion and admin handlers to use attribute value
- include upload_date when indexing and querying media

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68629879b20c832087eb18e65bc0bd5d