### PR TITLE
Limit vertical image previews to 3:1

### DIFF
--- a/web/src/lib/components/MediaGrid.svelte
+++ b/web/src/lib/components/MediaGrid.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import Masonry from './media_grid/Masonry.svelte'; // Masonry component
-	import type { MediaItem } from '$lib/types/media';
+	import type { MediaPreviewItem, MediaItem } from '$lib/types/media';
 	import { PAGE_SIZE } from '$lib/constants';
 	import { fetchMediaPreviews } from '$lib/api';
 
@@ -9,7 +9,7 @@
 	let lastQuery: string = $state('');
 	let lastPage: number = $state(1);
 
-	let media: MediaItem[] = $state([]);
+	let media: MediaPreviewItem[] = $state([]);
 	let innerWidth = $state(0);
 	let mounted = $state(false);
 	let scrollY = $state(0);
@@ -28,7 +28,17 @@
 	async function load() {
 		try {
 			const data = await fetchMediaPreviews(query, page, pageSize);
-			media = data.media as MediaItem[];
+			const items = data.media as MediaItem[];
+			media = items.map((it) => {
+				const displayHeight = Math.min(it.height, it.width * 3);
+				return {
+					...it,
+					height: displayHeight,
+					displayHeight,
+					originalHeight: it.height,
+					cropped: displayHeight < it.height
+				} satisfies MediaPreviewItem;
+			});
 			total = data.total ?? (1 as number);
 		} catch (err) {
 			console.error('media fetch error', err);

--- a/web/src/lib/components/media/MediaCard.svelte
+++ b/web/src/lib/components/media/MediaCard.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
-	import type { MediaItem } from '$lib/types/media';
+	import type { MediaPreviewItem } from '$lib/types/media';
 	import { isFormatVideo } from '$lib/utils/media_utils';
-	let { item } = $props<{ item: MediaItem }>();
+	let { item } = $props<{ item: MediaPreviewItem }>();
+
+	const needsCrop = $derived(item.cropped);
 
 	function getBorderStyle(format: string) {
 		if (isFormatVideo(format)) {
@@ -13,12 +15,25 @@
 </script>
 
 <a href={`/media/${item.id}`} class="group relative block">
-	<img
-		src={item.url}
-		alt={'media ' + item.id}
-		class={'h-auto w-full rounded-md object-contain shadow' + getBorderStyle(item.format)}
-		loading="lazy"
-	/>
+	<div
+		class="relative w-full overflow-hidden rounded-md"
+		style={`aspect-ratio:${item.width}/${item.height}`}
+	>
+		<img
+			src={item.url}
+			alt={'media ' + item.id}
+			class={'h-full w-full ' +
+				(needsCrop ? 'object-cover' : 'object-contain') +
+				' shadow' +
+				getBorderStyle(item.format)}
+			loading="lazy"
+		/>
+		{#if needsCrop}
+			<div
+				class="pointer-events-none absolute inset-x-0 bottom-0 h-10 bg-gradient-to-b from-transparent to-black/50"
+			></div>
+		{/if}
+	</div>
 	<div
 		class="absolute inset-0 rounded-md bg-black opacity-0 opacity-3 transition-opacity duration-200 group-hover:opacity-12"
 	></div>

--- a/web/src/lib/components/media/MediaCard.svelte
+++ b/web/src/lib/components/media/MediaCard.svelte
@@ -23,7 +23,7 @@
 			src={item.url}
 			alt={'media ' + item.id}
 			class={'h-full w-full ' +
-				(needsCrop ? 'object-cover' : 'object-contain') +
+				(needsCrop ? 'object-cover' : '') +
 				' shadow' +
 				getBorderStyle(item.format)}
 			loading="lazy"

--- a/web/src/lib/components/media_grid/Column.svelte
+++ b/web/src/lib/components/media_grid/Column.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import MediaCard from '../media/MediaCard.svelte';
-	import type { MediaItem } from '$lib/types/media';
+	import type { MediaPreviewItem } from '$lib/types/media';
 	import { ElementSize } from 'runed';
 	import { browser } from '$app/environment';
 
@@ -9,7 +9,7 @@
 		scrolledPercentage = 0,
 		maxHeight
 	} = $props<{
-		items: MediaItem[];
+		items: MediaPreviewItem[];
 		scrolledPercentage: number;
 		maxHeight: number;
 	}>();

--- a/web/src/lib/components/media_grid/Masonry.svelte
+++ b/web/src/lib/components/media_grid/Masonry.svelte
@@ -8,11 +8,11 @@
 		items = [],
 		columnWidths = ['1fr', '1fr'],
 		scrollPosition = 0
-	} = $props<{
-		items: MediaPreviewItem[];
-		columnWidths: string[];
-		scrollPosition: number;
-	}>();
+	}: {
+		items: MediaPreviewItem[],
+		columnWidths: string[], 
+		scrollPosition: number
+	} = $props();
 
 	let columns = $derived(
 		items.length > columnWidths.length

--- a/web/src/lib/components/media_grid/Masonry.svelte
+++ b/web/src/lib/components/media_grid/Masonry.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import Column from './Column.svelte';
 	import { distributeVertically, distributeRoundRobin } from '$lib/masonryDistribution';
-	import type { MediaItem } from '$lib/types/media';
+	import type { MediaPreviewItem } from '$lib/types/media';
 	import { ElementRect } from 'runed';
 
 	let {
@@ -9,15 +9,15 @@
 		columnWidths = ['1fr', '1fr'],
 		scrollPosition = 0
 	} = $props<{
-		items: MediaItem[];
+		items: MediaPreviewItem[];
 		columnWidths: string[];
 		scrollPosition: number;
 	}>();
 
 	let columns = $derived(
 		items.length > columnWidths.length
-			? distributeVertically(items as MediaItem[], columnWidths.length)
-			: distributeRoundRobin(items as MediaItem[], columnWidths.length)
+			? distributeVertically(items, columnWidths.length)
+			: distributeRoundRobin(items, columnWidths.length)
 	);
 
 	let el = $state<HTMLElement>();

--- a/web/src/lib/types/media.ts
+++ b/web/src/lib/types/media.ts
@@ -16,3 +16,15 @@ export interface MediaDetail extends MediaItem {
 	tags: string[];
 	dates: MediaDate[];
 }
+
+export interface MediaPreviewItem extends MediaItem {
+	/**
+	 * Height of the preview element. This may be smaller than the
+	 * original height when the image is cropped for display.
+	 */
+	displayHeight: number;
+	/** Height of the original image before cropping. */
+	originalHeight: number;
+	/** Whether the preview is cropped because it's too tall. */
+	cropped: boolean;
+}


### PR DESCRIPTION
## Summary
- extend media types with preview metadata
- adjust media loading to crop tall images to at most 3× width
- update masonry grid components to use preview data
- crop previews in `MediaCard` and add bottom shadow

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686e9b4225f48320a843d34fdc810c76