### PR TITLE
Show tag counts with links on media page

### DIFF
--- a/web/src/lib/types/media.ts
+++ b/web/src/lib/types/media.ts
@@ -13,8 +13,13 @@ export interface MediaItem {
 
 export interface MediaDetail extends MediaItem {
 	size: number;
-	tags: string[];
+	tags: TagCount[];
 	dates: MediaDate[];
+}
+
+export interface TagCount {
+	name: string;
+	count: number;
 }
 
 export interface MediaPreviewItem extends MediaItem {

--- a/web/src/routes/media/[id]/+page.svelte
+++ b/web/src/routes/media/[id]/+page.svelte
@@ -14,7 +14,7 @@
 		const id = page.params.id;
 		try {
 			media = await fetchMediaDetail(id);
-			tagsInput = media?.tags.map((t) => t.replace(/ /g, '_')).join(' ') ?? '';
+			tagsInput = media?.tags.map((t) => t.name.replace(/ /g, '_')).join(' ') ?? '';
 		} catch (err) {
 			console.error('failed to load media', err);
 		}
@@ -37,8 +37,8 @@
 		const tags = tagsInput.split(/\s+/).filter((t) => t.length > 0);
 		try {
 			await updateMediaTags(media.id, tags);
-			media.tags = tags;
-			tagsInput = media.tags.map((t) => t.replace(/ /g, '_')).join(' ');
+			media = await fetchMediaDetail(media.id);
+			tagsInput = media.tags.map((t) => t.name.replace(/ /g, '_')).join(' ');
 			edit = false;
 		} catch (err) {
 			console.error('failed to save tags', err);
@@ -74,8 +74,15 @@
 				<div class="text-sm">
 					<p class="font-semibold">Tags:</p>
 					<ul class="ml-4 list-disc">
-						{#each media.tags as t (t)}
-							<li>{t}</li>
+						{#each media.tags as t (t.name)}
+							<li>
+								<a
+									href={`/?q=${encodeURIComponent(t.name)}`}
+									class="text-blue-500 visited:text-blue-500 hover:underline"
+								>
+									{t.name} ({t.count})
+								</a>
+							</li>
 						{/each}
 					</ul>
 				</div>


### PR DESCRIPTION
## Summary
- return tag counts from `/api/media/:id`
- display tags with counts as links on the media page
- add TagCount type to match new API response

## Testing
- `npm run lint`
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68701159a6ac8320840196f22046d36d