### PR TITLE
Add tags listing page

### DIFF
--- a/internal/api/tags_handler.go
+++ b/internal/api/tags_handler.go
@@ -1,0 +1,43 @@
+package api
+
+import (
+	"log"
+	"net/http"
+	"sort"
+
+	"era/booru/ent"
+	"era/booru/ent/tag"
+
+	"github.com/gin-gonic/gin"
+)
+
+func RegisterTagRoutes(r *gin.Engine, db *ent.Client) {
+	r.GET("/api/tags", listTagsHandler(db))
+}
+
+func listTagsHandler(db *ent.Client) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		ctx := c.Request.Context()
+		tags, err := db.Tag.Query().All(ctx)
+		if err != nil {
+			log.Printf("list tags: %v", err)
+			c.AbortWithStatus(http.StatusInternalServerError)
+			return
+		}
+		out := make([]struct {
+			Name  string `json:"name"`
+			Count int    `json:"count"`
+		}, len(tags))
+		for i, t := range tags {
+			count, err := db.Tag.Query().Where(tag.IDEQ(t.ID)).QueryMedia().Count(ctx)
+			if err != nil {
+				log.Printf("count tag %s: %v", t.Name, err)
+				count = 0
+			}
+			out[i].Name = t.Name
+			out[i].Count = count
+		}
+		sort.Slice(out, func(i, j int) bool { return out[i].Count > out[j].Count })
+		c.JSON(http.StatusOK, gin.H{"tags": out})
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -87,6 +87,7 @@ func New(ctx context.Context, cfg *config.Config) (*Server, error) {
 	r.Use(api.GinLogger(), gin.Recovery(), api.CORSMiddleware())
 	r.GET("/health", func(c *gin.Context) { c.Status(http.StatusNoContent) })
 	api.RegisterMediaRoutes(r, database, m, cfg)
+	api.RegisterTagRoutes(r, database)
 	api.RegisterAdminRoutes(r, database, m, cfg, riverClient)
 	api.RegisterStaticRoutes(r)
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { MediaItem, MediaDetail } from './types/media';
+import type { MediaItem, MediaDetail, TagCount } from './types/media';
 
 const apiBase = '/api';
 
@@ -85,4 +85,10 @@ export async function importMediaTags(file: File): Promise<void> {
 		body: file
 	});
 	if (!res.ok) throw new Error(`HTTP ${res.status}`);
+}
+
+export async function fetchTags(): Promise<TagCount[]> {
+	const res = await fetch(`${apiBase}/tags`);
+	const data = await handleJson<{ tags: TagCount[] }>(res);
+	return data.tags;
 }

--- a/web/src/lib/components/TabNav.svelte
+++ b/web/src/lib/components/TabNav.svelte
@@ -9,7 +9,7 @@
 	import { PAGE_SIZE } from '$lib/constants';
 
 	let q: string = $state('');
-	let active: 'media' | 'upload' | 'settings' = $props();
+	let active: 'media' | 'upload' | 'tags' | 'settings' = $props();
 
 	onMount(() => {
 		q = get(page).url.searchParams.get('q') ?? '';
@@ -42,6 +42,16 @@
 			class:text-gray-500={active !== 'upload'}
 		>
 			Upload
+		</a>
+		<a
+			href="/tags"
+			class="-mb-px border-b-2 px-3 py-2"
+			class:!border-blue-500={active === 'tags'}
+			class:!text-blue-500={active === 'tags'}
+			class:border-transparent={active !== 'tags'}
+			class:text-gray-500={active !== 'tags'}
+		>
+			Tags
 		</a>
 		<a
 			href="/settings"

--- a/web/src/routes/tags/+page.svelte
+++ b/web/src/routes/tags/+page.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import TabNav from '$lib/components/TabNav.svelte';
+	import { fetchTags } from '$lib/api';
+	import type { TagCount } from '$lib/types/media';
+
+	let tags: TagCount[] = $state([]);
+
+	onMount(async () => {
+		try {
+			tags = await fetchTags();
+		} catch (err) {
+			console.error('failed to load tags', err);
+		}
+	});
+</script>
+
+<TabNav active="tags" />
+
+<table class="mx-auto mt-4">
+	<thead>
+		<tr>
+			<th class="px-2 py-1 text-left">Tag</th>
+			<th class="px-2 py-1 text-right">Count</th>
+		</tr>
+	</thead>
+	<tbody>
+		{#each tags as t (t.name)}
+			<tr>
+				<td class="px-2 py-1">
+					<a
+						href={`/?q=${encodeURIComponent(t.name)}`}
+						class="text-blue-500 visited:text-blue-500 hover:underline"
+					>
+						{t.name}
+					</a>
+				</td>
+				<td class="px-2 py-1 text-right">{t.count}</td>
+			</tr>
+		{/each}
+	</tbody>
+</table>


### PR DESCRIPTION
## Summary
- implement new API handler to list tags with counts
- expose `/api/tags` from the server
- extend TabNav with a Tags tab
- add frontend API helper and page to show tags table

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687035f8d1e483208dd5ebf804e9d766