### PR TITLE
Refactor worker packages for CGO isolation

### DIFF
--- a/cmd/image_embed_worker/main.go
+++ b/cmd/image_embed_worker/main.go
@@ -12,7 +12,7 @@ import (
 	embed "era/booru/internal/embeddings"
 	"era/booru/internal/minio"
 	"era/booru/internal/queue"
-	qworkers "era/booru/internal/queue/workers"
+	embedworker "era/booru/internal/workers/embedworker"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/riverqueue/river"
@@ -57,7 +57,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	river.AddWorker(workers, &qworkers.ImageEmbedWorker{Minio: m, DB: database})
+	river.AddWorker(workers, &embedworker.ImageEmbedWorker{Minio: m, DB: database})
 
 	if err := client.Start(ctx); err != nil {
 		log.Fatal(err)

--- a/cmd/media_worker/main.go
+++ b/cmd/media_worker/main.go
@@ -11,7 +11,8 @@ import (
 	"era/booru/internal/db"
 	"era/booru/internal/minio"
 	"era/booru/internal/queue"
-	qworkers "era/booru/internal/queue/workers"
+	indexworker "era/booru/internal/workers/indexworker"
+	mediaworker "era/booru/internal/workers/mediaworker"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/riverqueue/river"
@@ -55,13 +56,13 @@ func main() {
 	}
 
 	// Register worker
-	river.AddWorker(workers, &qworkers.ProcessWorker{
+	river.AddWorker(workers, &mediaworker.ProcessWorker{
 		Minio: m,
 		DB:    database,
 		Cfg:   cfg,
 	})
 
-	river.AddWorker(workers, &qworkers.IndexWorker{
+	river.AddWorker(workers, &indexworker.IndexWorker{
 		DB: database,
 	})
 

--- a/internal/integration/common/helpers.go
+++ b/internal/integration/common/helpers.go
@@ -18,7 +18,8 @@ import (
 	"era/booru/internal/db"
 	"era/booru/internal/minio"
 	"era/booru/internal/queue"
-	qworkers "era/booru/internal/queue/workers"
+	indexworker "era/booru/internal/workers/indexworker"
+	mediaworker "era/booru/internal/workers/mediaworker"
 )
 
 // ParseExport decompresses the provided gzip data and decodes the exported items.
@@ -89,12 +90,12 @@ func StartMediaWorker(t testing.TB, ctx context.Context, cfg *config.Config) *Me
 		t.Fatalf("minio: %v", err)
 	}
 
-	river.AddWorker(workers, &qworkers.ProcessWorker{
+	river.AddWorker(workers, &mediaworker.ProcessWorker{
 		Minio: m,
 		DB:    database,
 		Cfg:   cfg,
 	})
-	river.AddWorker(workers, &qworkers.IndexWorker{DB: database})
+	river.AddWorker(workers, &indexworker.IndexWorker{DB: database})
 
 	if err := client.Start(ctx); err != nil {
 		t.Fatalf("river start: %v", err)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -15,8 +15,9 @@ import (
 	"era/booru/internal/db"
 	"era/booru/internal/minio"
 	"era/booru/internal/queue"
-	qworkers "era/booru/internal/queue/workers"
 	"era/booru/internal/search"
+	indexworker "era/booru/internal/workers/indexworker"
+	mediaworker "era/booru/internal/workers/mediaworker"
 
 	"github.com/riverqueue/river"
 )
@@ -63,11 +64,11 @@ func New(ctx context.Context, cfg *config.Config) (*Server, error) {
 		return nil, err
 	}
 
-	river.AddWorker(workers, &qworkers.IndexWorker{DB: database})
+	river.AddWorker(workers, &indexworker.IndexWorker{DB: database})
 	if err := riverClient.Start(ctx); err != nil {
 		return nil, err
 	}
-	river.AddWorker(workers, &qworkers.ProcessWorker{
+	river.AddWorker(workers, &mediaworker.ProcessWorker{
 		Minio: m,
 		DB:    database,
 		Cfg:   cfg,

--- a/internal/workers/embedworker/image_embed_worker.go
+++ b/internal/workers/embedworker/image_embed_worker.go
@@ -1,4 +1,4 @@
-package workers
+package embedworker
 
 import (
 	"context"

--- a/internal/workers/indexworker/index_worker.go
+++ b/internal/workers/indexworker/index_worker.go
@@ -1,4 +1,4 @@
-package workers
+package indexworker
 
 import (
 	"context"

--- a/internal/workers/mediaworker/media_process_worker.go
+++ b/internal/workers/mediaworker/media_process_worker.go
@@ -1,4 +1,4 @@
-package workers
+package mediaworker
 
 import (
 	"context"


### PR DESCRIPTION
## Summary
- move each River worker into its own package so only the embed worker pulls in CGO-enabled dependencies
- update the server, worker binaries, and integration helpers to reference the new worker packages

## Testing
- go test ./...
- go vet ./...
- CGO_ENABLED=0 go build ./cmd/media_worker
- CGO_ENABLED=0 go build ./cmd/server

------
https://chatgpt.com/codex/tasks/task_e_68ca04665bb88320b0a754fa9359bdcf