### PR TITLE
Register embed job in media worker

### DIFF
--- a/cmd/media_worker/main.go
+++ b/cmd/media_worker/main.go
@@ -66,6 +66,14 @@ func main() {
 		DB: database,
 	})
 
+	// Register the embed job kind so this worker can enqueue embed tasks
+	// without importing the full embed worker implementation (and its CGO
+	// dependencies). The media worker never handles these jobs directly; they
+	// are picked up by the dedicated embed worker process.
+	river.AddWorker(workers, river.WorkFunc(func(ctx context.Context, job *river.Job[queue.EmbedArgs]) error {
+		return nil
+	}))
+
 	// Start processing
 	if err := client.Start(ctx); err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
## Summary
- register a no-op embed job handler with the media worker so it can enqueue embed jobs without importing the CGO-heavy embed worker implementation

## Testing
- go test ./...
- go vet ./...


------
https://chatgpt.com/codex/tasks/task_e_68cad9d9d09083208a2221533be1b0eb