### PR TITLE
Add similar media column powered by vector search

### DIFF
--- a/cmd/image_embed_worker/main.go
+++ b/cmd/image_embed_worker/main.go
@@ -43,7 +43,7 @@ func main() {
 	defer pool.Close()
 
 	workers := river.NewWorkers()
-	river.AddWorker(workers, river.WorkFunc(queue.IndexArgs{}, func(ctx context.Context, job *river.Job[queue.IndexArgs]) error {
+	river.AddWorker(workers, river.WorkFunc(func(ctx context.Context, job *river.Job[queue.IndexArgs]) error {
 		return fmt.Errorf("index job should not run in image embed worker: %s", job.Args.ID)
 	}))
 

--- a/cmd/image_embed_worker/main.go
+++ b/cmd/image_embed_worker/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"os"
 	"os/signal"
@@ -42,6 +43,10 @@ func main() {
 	defer pool.Close()
 
 	workers := river.NewWorkers()
+	river.AddWorker(workers, river.WorkFunc(queue.IndexArgs{}, func(ctx context.Context, job *river.Job[queue.IndexArgs]) error {
+		return fmt.Errorf("index job should not run in image embed worker: %s", job.Args.ID)
+	}))
+
 	client, err := queue.NewClient(ctx, pool, workers, queue.ClientTypeImageEmbWorker)
 	if err != nil {
 		log.Fatal(err)

--- a/internal/search/similar.go
+++ b/internal/search/similar.go
@@ -35,7 +35,7 @@ func SimilarMediaByVector(ctx context.Context, db *ent.Client, vectorName string
 			b.WriteString(mediavector.Table)
 			b.WriteByte('.')
 			b.WriteString(mediavector.FieldValue)
-			b.WriteString(" <#> ?")
+			b.WriteString(" <#> ")
 			b.Arg(vec)
 		}))
 	}).Limit(limit)

--- a/internal/search/similar.go
+++ b/internal/search/similar.go
@@ -1,0 +1,72 @@
+package search
+
+import (
+	"context"
+	"sort"
+
+	"era/booru/ent"
+	"era/booru/ent/media"
+	"era/booru/ent/mediavector"
+	"era/booru/ent/vector"
+
+	"entgo.io/ent/dialect/sql"
+	pgvector "github.com/pgvector/pgvector-go"
+)
+
+// SimilarMediaByVector returns media ordered by similarity to the provided
+// vector. When Bleve vector search is available the build can provide a
+// specialised implementation via build tags. The default implementation uses
+// pgvector for similarity calculation.
+func SimilarMediaByVector(ctx context.Context, db *ent.Client, vectorName string, query []float32, limit int, excludeID string) ([]*ent.Media, error) {
+	if limit <= 0 || len(query) == 0 {
+		return []*ent.Media{}, nil
+	}
+
+	vec := pgvector.NewVector(query)
+	mvQuery := db.MediaVector.Query().
+		Where(mediavector.HasVectorWith(vector.NameEQ(vectorName)))
+
+	if excludeID != "" {
+		mvQuery = mvQuery.Where(mediavector.MediaIDNEQ(excludeID))
+	}
+
+	mvQuery = mvQuery.Order(func(s *sql.Selector) {
+		s.OrderExpr(sql.ExprFunc(func(b *sql.Builder) {
+			b.WriteString(mediavector.Table)
+			b.WriteByte('.')
+			b.WriteString(mediavector.FieldValue)
+			b.WriteString(" <#> ?")
+			b.Arg(vec)
+		}))
+	}).Limit(limit)
+
+	ids, err := mvQuery.Select(mediavector.FieldMediaID).Strings(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if len(ids) == 0 {
+		return []*ent.Media{}, nil
+	}
+
+	medias, err := db.Media.Query().
+		Where(media.IDIn(ids...)).
+		All(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(medias) <= 1 {
+		return medias, nil
+	}
+
+	order := make(map[string]int, len(ids))
+	for idx, id := range ids {
+		order[id] = idx
+	}
+
+	sort.SliceStable(medias, func(i, j int) bool {
+		return order[medias[i].ID] < order[medias[j].ID]
+	})
+
+	return medias, nil
+}

--- a/internal/search/vector_mapping.go
+++ b/internal/search/vector_mapping.go
@@ -1,0 +1,8 @@
+package search
+
+import "github.com/blevesearch/bleve/v2/mapping"
+
+// configureVectorMapping applies vector field configuration when available.
+// In the current build this is a no-op, but the hook allows vector-enabled
+// builds to provide their own implementation.
+func configureVectorMapping(m mapping.IndexMapping) {}

--- a/internal/workers/embedworker/image_embed_worker.go
+++ b/internal/workers/embedworker/image_embed_worker.go
@@ -58,6 +58,10 @@ func (w *ImageEmbedWorker) Work(ctx context.Context, job *river.Job[queue.EmbedA
 		return err
 	}
 
+	if err := queue.WorkerEnqueue(ctx, queue.IndexArgs{ID: job.Args.Key}); err != nil {
+		log.Printf("Failed to enqueue reindex for %s: %v", job.Args.Key, err)
+	}
+
 	log.Printf("Successfully generated and saved embedding for key %s", job.Args.Key)
 	return nil
 }

--- a/internal/workers/indexworker/index_worker.go
+++ b/internal/workers/indexworker/index_worker.go
@@ -6,6 +6,7 @@ import (
 
 	"era/booru/ent"
 	"era/booru/ent/media"
+	"era/booru/ent/mediavector"
 
 	"era/booru/internal/queue"
 	"era/booru/internal/search"
@@ -24,6 +25,11 @@ func (w *IndexWorker) Work(ctx context.Context, job *river.Job[queue.IndexArgs])
 	mobj, err := w.DB.Media.Query().Where(media.IDEQ(job.Args.ID)).
 		WithTags().
 		WithDates(func(q *ent.DateQuery) { q.WithMediaDates() }).
+		WithVectors(func(q *ent.VectorQuery) {
+			q.WithMediaVectors(func(mvq *ent.MediaVectorQuery) {
+				mvq.Where(mediavector.MediaIDEQ(job.Args.ID))
+			})
+		}).
 		Only(ctx)
 	if ent.IsNotFound(err) {
 		log.Printf("Media with ID %s not found, deleting from index", job.Args.ID)

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -1,13 +1,16 @@
 # AGENTS Instructions for `web`
 
 ## Scope
+
 These instructions apply to all files in the `web/` directory.
 
 ## Svelte Runes
-- This project uses **Svelte 5** with the *runes* syntax. Always write components using runes like `$state`, `$derived`, `$effect`, etc.
+
+- This project uses **Svelte 5** with the _runes_ syntax. Always write components using runes like `$state`, `$derived`, `$effect`, etc.
 - Do **not** use the old reactive `$:` syntax or `$store` auto-subscriptions.
 
 ### Runes cheatsheet
+
 - `$state(initial)` – declare reactive state.
   ```svelte
   let count = $state(0);
@@ -26,11 +29,11 @@ These instructions apply to all files in the `web/` directory.
   ```
 - `$props()` – access component props.
   ```svelte
-  let { foo } = $props();
+  let {foo} = $props();
   ```
 - `$bindable()` – mark a prop as bindable for two‑way binding.
   ```svelte
-  let { value = $bindable() } = $props();
+  let {(value = $bindable())} = $props();
   ```
 - `$inspect(...vals)` – log values reactively during development.
   ```svelte
@@ -42,8 +45,11 @@ These instructions apply to all files in the `web/` directory.
   ```
 
 ## `Runed` library
+
 This project have Runed installed. Runed is handy library with rune-based helper functions. Here is names of those function, whole descriptions can be found [here](https://runed.dev/docs)
+
 #### ELEMENTS
+
 - `activeElement`
 - `ElementRect`
 - `ElementSize`
@@ -56,26 +62,32 @@ This project have Runed installed. Runed is handy library with rune-based helper
 - `useResizeObserver`
 
 #### BROWSER
+
 - `useEventListener`
 
 #### SENSORS
+
 - `IsIdle`
 - `onClickOutside`
 - `PressedKeys`
 - `useGeolocation`
 
 #### ANIMATION
+
 - `AnimationFrames`
 
 #### UTILITIES
+
 - `useDebounce`
 
 #### REACTIVITY
+
 - `extract`
 - `resource`
 - `watch`
 
 #### STATE
+
 - `Context`
 - `Debounced`
 - `FiniteStateMachine`
@@ -84,7 +96,9 @@ This project have Runed installed. Runed is handy library with rune-based helper
 - `StateHistory`
 
 #### COMPONENT
+
 - `IsMounted`
 
 ## Formatting
+
 Run `npm run lint` inside this folder before committing frontend changes to ensure Prettier and ESLint pass.

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -92,3 +92,18 @@ export async function fetchTags(): Promise<TagCount[]> {
 	const data = await handleJson<{ tags: TagCount[] }>(res);
 	return data.tags;
 }
+
+export async function fetchSimilarMedia(
+	vector: number[],
+	limit: number,
+	exclude?: string,
+	name = 'vision'
+): Promise<MediaItem[]> {
+	const res = await fetch(`${apiBase}/media/similar`, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify({ vector, limit, exclude, name })
+	});
+	const data = await handleJson<{ media: MediaItem[] }>(res);
+	return data.media;
+}

--- a/web/src/lib/components/media_grid/Masonry.svelte
+++ b/web/src/lib/components/media_grid/Masonry.svelte
@@ -9,9 +9,9 @@
 		columnWidths = ['1fr', '1fr'],
 		scrollPosition = 0
 	}: {
-		items: MediaPreviewItem[],
-		columnWidths: string[], 
-		scrollPosition: number
+		items: MediaPreviewItem[];
+		columnWidths: string[];
+		scrollPosition: number;
 	} = $props();
 
 	let columns = $derived(

--- a/web/src/lib/types/media.ts
+++ b/web/src/lib/types/media.ts
@@ -15,6 +15,12 @@ export interface MediaDetail extends MediaItem {
 	size: number;
 	tags: TagCount[];
 	dates: MediaDate[];
+	vectors?: MediaVector[];
+}
+
+export interface MediaVector {
+	name: string;
+	value: number[];
 }
 
 export interface TagCount {


### PR DESCRIPTION
## Summary
- store media embedding vectors in the Bleve documents and trigger reindexing after embeddings are generated
- add a backend helper and `/api/media/similar` endpoint that return nearest media using the stored vectors
- update the media detail page to fetch similar items and render a third column alongside metadata and the main preview
- format affected web files with Prettier so the lint task succeeds

## Testing
- npm run lint
- go test ./... *(fails: image embedding packages require the optional `embeddings` build tag)*

------
https://chatgpt.com/codex/tasks/task_e_68cdec05fe748320834126b7459ccb3d