### PR TITLE
Prefer pooled ONNX embeddings

### DIFF
--- a/internal/embeddings/loader.go
+++ b/internal/embeddings/loader.go
@@ -82,7 +82,13 @@ func Load(dir string) error {
 			return ""
 		}
 
-		outputName = chooseOutput("image_embeds", "last_hidden_state")
+		outputName = chooseOutput(
+			"pooler_output",
+			"image_embeds",
+			"image_features",
+			"img_embeds",
+			"embeddings",
+		)
 		if outputName == "" {
 			// Fall back to the first float tensor output if the preferred
 			// names are absent so we can support future exports without


### PR DESCRIPTION
## Summary
- prefer pooled ONNX outputs when initialising the vision embedding session
- fall back to other float tensor outputs without using the noisy last_hidden_state tensor

## Testing
- `go test -tags=embeddings ./...`


------
https://chatgpt.com/codex/tasks/task_e_68d45a6275308320bf2a26397a719506