### PR TITLE
Add module documentation file to enable go commands

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,5 @@
+// Package booru provides module-level documentation for Erabooru.
+//
+// Having a Go source file at the module root ensures that commands such as
+// `go test` and `go vet` work without requiring explicit package patterns.
+package booru


### PR DESCRIPTION
## Summary
- add a module-level documentation file at the repository root so `go vet` and `go test` can run without explicit package patterns

## Testing
- go vet
- go test


------
https://chatgpt.com/codex/tasks/task_e_68d8851a92dc83208a4439937680fc5a