### PR TITLE
Fix TabNav URLSearchParams usage

### DIFF
--- a/web/src/lib/components/TabNav.svelte
+++ b/web/src/lib/components/TabNav.svelte
@@ -33,7 +33,7 @@
 		const trimmed = tagQuery.trim();
 		const params = new URLSearchParams({
 			page: '1',
-			page_size: PAGE_SIZE
+			page_size: String(PAGE_SIZE)
 		});
 		if (trimmed) {
 			params.set('q', trimmed);
@@ -46,7 +46,7 @@
 		const trimmed = textQuery.trim();
 		const params = new URLSearchParams({
 			page: '1',
-			page_size: PAGE_SIZE,
+			page_size: String(PAGE_SIZE),
 			vector: '1'
 		});
 		if (trimmed) {


### PR DESCRIPTION
## Summary
- convert TabNav page size parameter to a string before creating URLSearchParams
- ensure both tag and vector searches use stringified page size to satisfy TypeScript

## Testing
- npx svelte-check
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d8bcac3158832096e7ffc1c2ed564f