### PR TITLE
Batch video frame embeddings for faster processing

### DIFF
--- a/internal/embeddings/dummy.go
+++ b/internal/embeddings/dummy.go
@@ -4,11 +4,16 @@ package embed
 
 import (
 	"context"
+	"image"
 )
 
 // Dummy stubs for vet/test without embeddings tag.
 
 func VisionEmbedding(any interface{}) ([]float32, error) {
+	return nil, nil
+}
+
+func VisionEmbeddingBatch([]image.Image) ([][]float32, error) {
 	return nil, nil
 }
 


### PR DESCRIPTION
## Summary
- add a batch vision embedding path to reuse the ONNX session for multiple frames
- switch the video embedding worker to process extracted frames in a single batch
- update the dummy embedding stubs to account for the new batch API

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68db849295048320910abf8bc69e7d2e