### PR TITLE
Use libvips for embedding preprocessing

### DIFF
--- a/cmd/image_embed_worker/Dockerfile
+++ b/cmd/image_embed_worker/Dockerfile
@@ -15,11 +15,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Install libvips from the official prebuilt package so we match the
 # generated bindings shipped with github.com/cshum/vipsgen (libvips 8.17).
-RUN wget -q https://github.com/kleisauke/libvips-packaging/releases/download/v${LIBVIPS_VERSION}/${LIBVIPS_PACKAGE} \
-    && mkdir -p /opt \
-    && tar -xzf ${LIBVIPS_PACKAGE} -C /opt \
-    && mv /opt/libvips-${LIBVIPS_VERSION}-linux-x64 /opt/libvips \
-    && rm ${LIBVIPS_PACKAGE}
+RUN set -eux; \
+    wget -q "https://github.com/kleisauke/libvips-packaging/releases/download/v${LIBVIPS_VERSION}/${LIBVIPS_PACKAGE}"; \
+    mkdir -p /opt; \
+    tar -xzf "${LIBVIPS_PACKAGE}" -C /opt; \
+    LIBVIPS_DIR="$(tar -tzf "${LIBVIPS_PACKAGE}" | head -1 | cut -d/ -f1)"; \
+    rm -rf /opt/libvips; \
+    mv "/opt/${LIBVIPS_DIR}" /opt/libvips; \
+    rm "${LIBVIPS_PACKAGE}"
 
 ENV PKG_CONFIG_PATH="/opt/libvips/lib/pkgconfig:${PKG_CONFIG_PATH}"
 ENV LD_LIBRARY_PATH="/opt/libvips/lib:${LD_LIBRARY_PATH}"
@@ -65,11 +68,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
  && rm -rf /var/lib/apt/lists/*
 
 # Install libvips runtime libraries to match the builder stage
-RUN wget -q https://github.com/kleisauke/libvips-packaging/releases/download/v${LIBVIPS_VERSION}/${LIBVIPS_PACKAGE} \
-    && mkdir -p /opt \
-    && tar -xzf ${LIBVIPS_PACKAGE} -C /opt \
-    && mv /opt/libvips-${LIBVIPS_VERSION}-linux-x64 /opt/libvips \
-    && rm ${LIBVIPS_PACKAGE}
+RUN set -eux; \
+    wget -q "https://github.com/kleisauke/libvips-packaging/releases/download/v${LIBVIPS_VERSION}/${LIBVIPS_PACKAGE}"; \
+    mkdir -p /opt; \
+    tar -xzf "${LIBVIPS_PACKAGE}" -C /opt; \
+    LIBVIPS_DIR="$(tar -tzf "${LIBVIPS_PACKAGE}" | head -1 | cut -d/ -f1)"; \
+    rm -rf /opt/libvips; \
+    mv "/opt/${LIBVIPS_DIR}" /opt/libvips; \
+    rm "${LIBVIPS_PACKAGE}"
 
 # Install ONNX Runtime in runtime stage
 RUN wget -q https://github.com/microsoft/onnxruntime/releases/download/v${ONNXRUNTIME_VERSION}/onnxruntime-linux-x64-${ONNXRUNTIME_VERSION}.tgz \

--- a/cmd/image_embed_worker/Dockerfile
+++ b/cmd/image_embed_worker/Dockerfile
@@ -3,31 +3,58 @@ FROM golang:1.25-bookworm AS builder
 
 ARG ONNXRUNTIME_VERSION=1.22.0
 ARG LIBVIPS_VERSION=8.17.2
-ARG LIBVIPS_PACKAGE=libvips-${LIBVIPS_VERSION}-linux-x64.tar.gz
 
-# Install build dependencies for CGO and download helpers
+# CGO + libvips build deps
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     ca-certificates \
     pkg-config \
+    git \
+    meson \
+    ninja-build \
+    python3 \
+    python3-pip \
+    gettext \
+    # vips deps
+    libglib2.0-dev \
+    libexpat1-dev \
+    zlib1g-dev \
+    libjpeg62-turbo-dev \
+    libpng-dev \
+    libtiff-dev \
+    libwebp-dev \
+    libexif-dev \
+    liborc-0.4-dev \
     wget \
  && rm -rf /var/lib/apt/lists/*
 
-# Install libvips from the official prebuilt package so we match the
-# generated bindings shipped with github.com/cshum/vipsgen (libvips 8.17).
+# ---- Build libvips 8.17.x from source into /opt/libvips ----
 RUN set -eux; \
-    wget -q "https://github.com/kleisauke/libvips-packaging/releases/download/v${LIBVIPS_VERSION}/${LIBVIPS_PACKAGE}"; \
-    mkdir -p /opt; \
-    tar -xzf "${LIBVIPS_PACKAGE}" -C /opt; \
-    LIBVIPS_DIR="$(tar -tzf "${LIBVIPS_PACKAGE}" | head -1 | cut -d/ -f1)"; \
-    rm -rf /opt/libvips; \
-    mv "/opt/${LIBVIPS_DIR}" /opt/libvips; \
-    rm "${LIBVIPS_PACKAGE}"
+    git clone --depth 1 --branch v${LIBVIPS_VERSION} https://github.com/libvips/libvips.git /tmp/libvips; \
+    cd /tmp/libvips; \
+    meson setup build \
+      --prefix=/opt/libvips \
+      -Dexamples=false \
+      -Dintrospection=disabled \
+      -Ddeprecated=true \
+      -Dmodules=enabled \
+      -Dmagick=disabled \
+      -Dopenslide=disabled \
+      -Dpdfium=disabled \
+      -Dpoppler=disabled \
+      -Dcfitsio=disabled \
+      -Djpeg-xl=disabled; \
+    meson compile -C build; \
+    meson install -C build; \
+    cd /; rm -rf /tmp/libvips
 
-ENV PKG_CONFIG_PATH="/opt/libvips/lib/pkgconfig:${PKG_CONFIG_PATH}"
-ENV LD_LIBRARY_PATH="/opt/libvips/lib:${LD_LIBRARY_PATH}"
+# Make pkg-config and linker see our libvips
+ENV PKG_CONFIG_PATH="/opt/libvips/lib/pkgconfig:/opt/libvips/lib/x86_64-linux-gnu/pkgconfig:${PKG_CONFIG_PATH}"
+ENV LD_LIBRARY_PATH="/opt/libvips/lib:/opt/libvips/lib/x86_64-linux-gnu:${LD_LIBRARY_PATH}"
 
-# Install ONNX Runtime
+RUN pkg-config --modversion vips && pkg-config --cflags --libs vips
+
+# ---- ONNX Runtime (CPU) ----
 RUN wget -q https://github.com/microsoft/onnxruntime/releases/download/v${ONNXRUNTIME_VERSION}/onnxruntime-linux-x64-${ONNXRUNTIME_VERSION}.tgz \
     && tar -xzf onnxruntime-linux-x64-${ONNXRUNTIME_VERSION}.tgz \
     && mkdir -p /opt/onnxruntime \
@@ -40,44 +67,47 @@ RUN wget -q https://github.com/microsoft/onnxruntime/releases/download/v${ONNXRU
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download
+
+# Copy sources
 COPY cmd/image_embed_worker/ ./cmd/image_embed_worker/
 COPY internal/ ./internal/
 COPY ent/ ./ent/
 
-# Build with CGO enabled and explicit paths
+# CGO flags for ONNX Runtime
 ENV CGO_CFLAGS="-I/opt/onnxruntime/include"
 ENV CGO_LDFLAGS="-L/opt/onnxruntime/lib -lonnxruntime"
-ENV LD_LIBRARY_PATH="/opt/onnxruntime/lib:/opt/libvips/lib"
+ENV LD_LIBRARY_PATH="/opt/onnxruntime/lib:/opt/libvips/lib:/opt/libvips/lib/x86_64-linux-gnu:${LD_LIBRARY_PATH}"
+
+# Build
 RUN CGO_ENABLED=1 go build -tags="embeddings" -o /bin/image_embed_worker ./cmd/image_embed_worker
 
 # ---------- runtime stage ----------
 FROM debian:bookworm-slim
 
 ARG ONNXRUNTIME_VERSION=1.22.0
-ARG LIBVIPS_VERSION=8.17.2
-ARG LIBVIPS_PACKAGE=libvips-${LIBVIPS_VERSION}-linux-x64.tar.gz
 
-# Install runtime dependencies and download helpers
+# Runtime libs (match codecs enabled above)
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     ffmpeg \
     libc6 \
     libgcc-s1 \
     libstdc++6 \
+    liborc-0.4-0 \
+    libjpeg62-turbo \
+    libpng16-16 \
+    libtiff6 \
+    libwebp7 \
+    libwebpdemux2 \
+    libwebpmux3 \
+    libexif12 \
     wget \
  && rm -rf /var/lib/apt/lists/*
 
-# Install libvips runtime libraries to match the builder stage
-RUN set -eux; \
-    wget -q "https://github.com/kleisauke/libvips-packaging/releases/download/v${LIBVIPS_VERSION}/${LIBVIPS_PACKAGE}"; \
-    mkdir -p /opt; \
-    tar -xzf "${LIBVIPS_PACKAGE}" -C /opt; \
-    LIBVIPS_DIR="$(tar -tzf "${LIBVIPS_PACKAGE}" | head -1 | cut -d/ -f1)"; \
-    rm -rf /opt/libvips; \
-    mv "/opt/${LIBVIPS_DIR}" /opt/libvips; \
-    rm "${LIBVIPS_PACKAGE}"
+# Bring the libvips we built
+COPY --from=builder /opt/libvips /opt/libvips
 
-# Install ONNX Runtime in runtime stage
+# ---- ONNX Runtime runtime ----
 RUN wget -q https://github.com/microsoft/onnxruntime/releases/download/v${ONNXRUNTIME_VERSION}/onnxruntime-linux-x64-${ONNXRUNTIME_VERSION}.tgz \
     && tar -xzf onnxruntime-linux-x64-${ONNXRUNTIME_VERSION}.tgz \
     && mkdir -p /opt/onnxruntime \
@@ -87,8 +117,7 @@ RUN wget -q https://github.com/microsoft/onnxruntime/releases/download/v${ONNXRU
     && ldconfig \
     && rm -rf onnxruntime-linux-x64-${ONNXRUNTIME_VERSION}*
 
-ENV LD_LIBRARY_PATH="/opt/onnxruntime/lib:/opt/libvips/lib"
+ENV LD_LIBRARY_PATH="/opt/onnxruntime/lib:/opt/libvips/lib:/opt/libvips/lib/x86_64-linux-gnu:${LD_LIBRARY_PATH}"
 
 COPY --from=builder /bin/image_embed_worker /usr/local/bin/image_embed_worker
-
 ENTRYPOINT ["image_embed_worker"]

--- a/cmd/image_embed_worker/Dockerfile
+++ b/cmd/image_embed_worker/Dockerfile
@@ -1,18 +1,27 @@
 # ---------- build stage ----------
 FROM golang:1.25-bookworm AS builder
 
-# Install build dependencies for CGO
-RUN apt-get update && apt-get install -y gcc libc6-dev wget build-essential && rm -rf /var/lib/apt/lists/*
+ARG ONNXRUNTIME_VERSION=1.22.0
 
-# Install ONNX Runtime 1.22.0
-RUN wget -q https://github.com/microsoft/onnxruntime/releases/download/v1.22.0/onnxruntime-linux-x64-1.22.0.tgz \
-    && tar -xzf onnxruntime-linux-x64-1.22.0.tgz \
+# Install build dependencies for CGO and libvips
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    ca-certificates \
+    libc6-dev \
+    libvips-dev \
+    pkg-config \
+    wget \
+ && rm -rf /var/lib/apt/lists/*
+
+# Install ONNX Runtime
+RUN wget -q https://github.com/microsoft/onnxruntime/releases/download/v${ONNXRUNTIME_VERSION}/onnxruntime-linux-x64-${ONNXRUNTIME_VERSION}.tgz \
+    && tar -xzf onnxruntime-linux-x64-${ONNXRUNTIME_VERSION}.tgz \
     && mkdir -p /opt/onnxruntime \
-    && cp -r onnxruntime-linux-x64-1.22.0/* /opt/onnxruntime/ \
-    && ln -sf /opt/onnxruntime/lib/libonnxruntime.so.1.22.0 /opt/onnxruntime/lib/onnxruntime.so \
+    && cp -r onnxruntime-linux-x64-${ONNXRUNTIME_VERSION}/* /opt/onnxruntime/ \
+    && ln -sf /opt/onnxruntime/lib/libonnxruntime.so.${ONNXRUNTIME_VERSION} /opt/onnxruntime/lib/onnxruntime.so \
     && echo "/opt/onnxruntime/lib" > /etc/ld.so.conf.d/onnxruntime.conf \
     && ldconfig \
-    && rm -rf onnxruntime-linux-x64-1.22.0*
+    && rm -rf onnxruntime-linux-x64-${ONNXRUNTIME_VERSION}*
 
 WORKDIR /src
 COPY go.mod go.sum ./
@@ -30,25 +39,28 @@ RUN CGO_ENABLED=1 go build -tags="embeddings" -o /bin/image_embed_worker ./cmd/i
 # ---------- runtime stage ----------
 FROM debian:bookworm-slim
 
-# Install runtime dependencies
-RUN apt-get update && apt-get install -y \
+ARG ONNXRUNTIME_VERSION=1.22.0
+
+# Install runtime dependencies, including libvips shared libraries
+RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     ffmpeg \
     libc6 \
     libgcc-s1 \
     libstdc++6 \
+    libvips42 \
     wget \
-    && rm -rf /var/lib/apt/lists/*
+ && rm -rf /var/lib/apt/lists/*
 
-# Install ONNX Runtime 1.22.0 in runtime stage
-RUN wget -q https://github.com/microsoft/onnxruntime/releases/download/v1.22.0/onnxruntime-linux-x64-1.22.0.tgz \
-    && tar -xzf onnxruntime-linux-x64-1.22.0.tgz \
+# Install ONNX Runtime in runtime stage
+RUN wget -q https://github.com/microsoft/onnxruntime/releases/download/v${ONNXRUNTIME_VERSION}/onnxruntime-linux-x64-${ONNXRUNTIME_VERSION}.tgz \
+    && tar -xzf onnxruntime-linux-x64-${ONNXRUNTIME_VERSION}.tgz \
     && mkdir -p /opt/onnxruntime \
-    && cp -r onnxruntime-linux-x64-1.22.0/* /opt/onnxruntime/ \
-    && ln -sf /opt/onnxruntime/lib/libonnxruntime.so.1.22.0 /opt/onnxruntime/lib/onnxruntime.so \
+    && cp -r onnxruntime-linux-x64-${ONNXRUNTIME_VERSION}/* /opt/onnxruntime/ \
+    && ln -sf /opt/onnxruntime/lib/libonnxruntime.so.${ONNXRUNTIME_VERSION} /opt/onnxruntime/lib/onnxruntime.so \
     && echo "/opt/onnxruntime/lib" > /etc/ld.so.conf.d/onnxruntime.conf \
     && ldconfig \
-    && rm -rf onnxruntime-linux-x64-1.22.0*
+    && rm -rf onnxruntime-linux-x64-${ONNXRUNTIME_VERSION}*
 
 ENV LD_LIBRARY_PATH="/opt/onnxruntime/lib"
 

--- a/cmd/image_embed_worker/Dockerfile
+++ b/cmd/image_embed_worker/Dockerfile
@@ -16,8 +16,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Install libvips from the official prebuilt package so we match the
 # generated bindings shipped with github.com/cshum/vipsgen (libvips 8.17).
 RUN wget -q https://github.com/kleisauke/libvips-packaging/releases/download/v${LIBVIPS_VERSION}/${LIBVIPS_PACKAGE} \
-    && mkdir -p /opt/libvips \
-    && tar -xzf ${LIBVIPS_PACKAGE} -C /opt/libvips \
+    && mkdir -p /opt \
+    && tar -xzf ${LIBVIPS_PACKAGE} -C /opt \
+    && mv /opt/libvips-${LIBVIPS_VERSION}-linux-x64 /opt/libvips \
     && rm ${LIBVIPS_PACKAGE}
 
 ENV PKG_CONFIG_PATH="/opt/libvips/lib/pkgconfig:${PKG_CONFIG_PATH}"
@@ -65,8 +66,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Install libvips runtime libraries to match the builder stage
 RUN wget -q https://github.com/kleisauke/libvips-packaging/releases/download/v${LIBVIPS_VERSION}/${LIBVIPS_PACKAGE} \
-    && mkdir -p /opt/libvips \
-    && tar -xzf ${LIBVIPS_PACKAGE} -C /opt/libvips \
+    && mkdir -p /opt \
+    && tar -xzf ${LIBVIPS_PACKAGE} -C /opt \
+    && mv /opt/libvips-${LIBVIPS_VERSION}-linux-x64 /opt/libvips \
     && rm ${LIBVIPS_PACKAGE}
 
 # Install ONNX Runtime in runtime stage

--- a/cmd/image_embed_worker/Dockerfile
+++ b/cmd/image_embed_worker/Dockerfile
@@ -16,9 +16,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Install libvips from the official prebuilt package so we match the
 # generated bindings shipped with github.com/cshum/vipsgen (libvips 8.17).
 RUN wget -q https://github.com/kleisauke/libvips-packaging/releases/download/v${LIBVIPS_VERSION}/${LIBVIPS_PACKAGE} \
-    && mkdir -p /opt \
-    && tar -xzf ${LIBVIPS_PACKAGE} -C /opt \
-    && mv /opt/libvips-${LIBVIPS_VERSION}-linux-x64 /opt/libvips \
+    && mkdir -p /opt/libvips \
+    && tar -xzf ${LIBVIPS_PACKAGE} -C /opt/libvips \
     && rm ${LIBVIPS_PACKAGE}
 
 ENV PKG_CONFIG_PATH="/opt/libvips/lib/pkgconfig:${PKG_CONFIG_PATH}"
@@ -66,9 +65,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Install libvips runtime libraries to match the builder stage
 RUN wget -q https://github.com/kleisauke/libvips-packaging/releases/download/v${LIBVIPS_VERSION}/${LIBVIPS_PACKAGE} \
-    && mkdir -p /opt \
-    && tar -xzf ${LIBVIPS_PACKAGE} -C /opt \
-    && mv /opt/libvips-${LIBVIPS_VERSION}-linux-x64 /opt/libvips \
+    && mkdir -p /opt/libvips \
+    && tar -xzf ${LIBVIPS_PACKAGE} -C /opt/libvips \
     && rm ${LIBVIPS_PACKAGE}
 
 # Install ONNX Runtime in runtime stage

--- a/cmd/image_embed_worker/Dockerfile
+++ b/cmd/image_embed_worker/Dockerfile
@@ -2,16 +2,27 @@
 FROM golang:1.25-bookworm AS builder
 
 ARG ONNXRUNTIME_VERSION=1.22.0
+ARG LIBVIPS_VERSION=8.17.2
+ARG LIBVIPS_PACKAGE=libvips-${LIBVIPS_VERSION}-linux-x64.tar.gz
 
-# Install build dependencies for CGO and libvips
+# Install build dependencies for CGO and download helpers
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     ca-certificates \
-    libc6-dev \
-    libvips-dev \
     pkg-config \
     wget \
  && rm -rf /var/lib/apt/lists/*
+
+# Install libvips from the official prebuilt package so we match the
+# generated bindings shipped with github.com/cshum/vipsgen (libvips 8.17).
+RUN wget -q https://github.com/kleisauke/libvips-packaging/releases/download/v${LIBVIPS_VERSION}/${LIBVIPS_PACKAGE} \
+    && mkdir -p /opt \
+    && tar -xzf ${LIBVIPS_PACKAGE} -C /opt \
+    && mv /opt/libvips-${LIBVIPS_VERSION}-linux-x64 /opt/libvips \
+    && rm ${LIBVIPS_PACKAGE}
+
+ENV PKG_CONFIG_PATH="/opt/libvips/lib/pkgconfig:${PKG_CONFIG_PATH}"
+ENV LD_LIBRARY_PATH="/opt/libvips/lib:${LD_LIBRARY_PATH}"
 
 # Install ONNX Runtime
 RUN wget -q https://github.com/microsoft/onnxruntime/releases/download/v${ONNXRUNTIME_VERSION}/onnxruntime-linux-x64-${ONNXRUNTIME_VERSION}.tgz \
@@ -33,24 +44,32 @@ COPY ent/ ./ent/
 # Build with CGO enabled and explicit paths
 ENV CGO_CFLAGS="-I/opt/onnxruntime/include"
 ENV CGO_LDFLAGS="-L/opt/onnxruntime/lib -lonnxruntime"
-ENV LD_LIBRARY_PATH="/opt/onnxruntime/lib"
+ENV LD_LIBRARY_PATH="/opt/onnxruntime/lib:/opt/libvips/lib"
 RUN CGO_ENABLED=1 go build -tags="embeddings" -o /bin/image_embed_worker ./cmd/image_embed_worker
 
 # ---------- runtime stage ----------
 FROM debian:bookworm-slim
 
 ARG ONNXRUNTIME_VERSION=1.22.0
+ARG LIBVIPS_VERSION=8.17.2
+ARG LIBVIPS_PACKAGE=libvips-${LIBVIPS_VERSION}-linux-x64.tar.gz
 
-# Install runtime dependencies, including libvips shared libraries
+# Install runtime dependencies and download helpers
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     ffmpeg \
     libc6 \
     libgcc-s1 \
     libstdc++6 \
-    libvips42 \
     wget \
  && rm -rf /var/lib/apt/lists/*
+
+# Install libvips runtime libraries to match the builder stage
+RUN wget -q https://github.com/kleisauke/libvips-packaging/releases/download/v${LIBVIPS_VERSION}/${LIBVIPS_PACKAGE} \
+    && mkdir -p /opt \
+    && tar -xzf ${LIBVIPS_PACKAGE} -C /opt \
+    && mv /opt/libvips-${LIBVIPS_VERSION}-linux-x64 /opt/libvips \
+    && rm ${LIBVIPS_PACKAGE}
 
 # Install ONNX Runtime in runtime stage
 RUN wget -q https://github.com/microsoft/onnxruntime/releases/download/v${ONNXRUNTIME_VERSION}/onnxruntime-linux-x64-${ONNXRUNTIME_VERSION}.tgz \
@@ -62,7 +81,7 @@ RUN wget -q https://github.com/microsoft/onnxruntime/releases/download/v${ONNXRU
     && ldconfig \
     && rm -rf onnxruntime-linux-x64-${ONNXRUNTIME_VERSION}*
 
-ENV LD_LIBRARY_PATH="/opt/onnxruntime/lib"
+ENV LD_LIBRARY_PATH="/opt/onnxruntime/lib:/opt/libvips/lib"
 
 COPY --from=builder /bin/image_embed_worker /usr/local/bin/image_embed_worker
 

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,8 @@ require (
 )
 
 require (
-	github.com/emirpasic/gods v1.18.1 // indirect
+        github.com/cshum/vipsgen v1.1.2
+        github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db // indirect
 	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
@@ -66,7 +67,6 @@ require (
 	github.com/containerd/platforms v0.2.1 // indirect
 	github.com/cpuguy83/dockercfg v0.3.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/disintegration/imaging v1.6.2 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/docker v28.0.1+incompatible // indirect
 	github.com/docker/go-connections v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -90,6 +90,8 @@ github.com/cpuguy83/dockercfg v0.3.2 h1:DlJTyZGBDlXqUZ2Dk2Q3xHs/FtnooJJVaad2S9GK
 github.com/cpuguy83/dockercfg v0.3.2/go.mod h1:sugsbF4//dDlL/i+S+rtpIWp+5h0BHJHfjj5/jFyUJc=
 github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
 github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
+github.com/cshum/vipsgen v1.1.2 h1:7kFUxlCBx4bAd69YwWagOGYC8/7vkXJuzCFV6tmPYvU=
+github.com/cshum/vipsgen v1.1.2/go.mod h1:1GboZQcNmo4NwuNnGogM24m3O+1i6UpnvurqMcsFItE=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/internal/embeddings/dummy.go
+++ b/internal/embeddings/dummy.go
@@ -8,7 +8,7 @@ import (
 
 // Dummy stubs for vet/test without embeddings tag.
 
-func VisionEmbedding(any interface{}) ([]float32, error) {
+func VisionEmbedding([]byte) ([]float32, error) {
 	return nil, nil
 }
 

--- a/internal/embeddings/vision.go
+++ b/internal/embeddings/vision.go
@@ -4,23 +4,38 @@ package embed
 
 import (
 	"fmt"
-	"image"
 	"math"
+	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 
-	"github.com/disintegration/imaging"
+	"github.com/cshum/vipsgen/vips"
 	ort "github.com/yalue/onnxruntime_go"
 )
 
-// VisionEmbedding converts an image to an L2-normalised embedding vector.
-func VisionEmbedding(img image.Image) ([]float32, error) {
+var vipsOnce sync.Once
+
+func ensureVips() {
+	vipsOnce.Do(func() {
+		vips.Startup(&vips.Config{ConcurrencyLevel: runtime.NumCPU()})
+	})
+}
+
+// VisionEmbedding converts an image buffer to an L2-normalised embedding vector.
+func VisionEmbedding(buf []byte) ([]float32, error) {
+	if len(buf) == 0 {
+		return nil, fmt.Errorf("vision embedding: empty image buffer")
+	}
+
+	ensureVips()
+
 	const maxAttempts = 3
 
 	var lastErr error
 	for attempt := 0; attempt < maxAttempts; attempt++ {
 		S := InputSpatialSize()
-		vec, err := visionEmbeddingWithSize(img, S)
+		vec, err := visionEmbeddingWithSize(buf, S)
 		if err == nil {
 			return vec, nil
 		}
@@ -51,21 +66,109 @@ func l2(v []float32) {
 	}
 }
 
-func visionEmbeddingWithSize(src image.Image, S int) ([]float32, error) {
+func visionEmbeddingWithSize(buf []byte, S int) ([]float32, error) {
 	if S <= 0 {
 		return nil, fmt.Errorf("invalid vision input size %d", S)
 	}
 
-	img := imaging.Fill(src, S, S, imaging.Center, imaging.Lanczos)
+	loadOptions := vips.DefaultLoadOptions()
+	loadOptions.Autorotate = true
+
+	thumbOptions := &vips.ThumbnailBufferOptions{
+		OptionString: loadOptions.OptionString(),
+		Height:       S,
+		Size:         vips.SizeBoth,
+		Crop:         vips.InterestingCentre,
+		FailOn:       vips.FailOnError,
+	}
+
+	img, err := vips.NewThumbnailBuffer(buf, S, thumbOptions)
+	if err != nil {
+		return nil, fmt.Errorf("vips thumbnail: %w", err)
+	}
+	defer func() {
+		if img != nil {
+			img.Close()
+		}
+	}()
+
+	if err := img.Colourspace(vips.InterpretationSrgb, nil); err != nil {
+		return nil, fmt.Errorf("vips colourspace: %w", err)
+	}
+
+	if img.HasAlpha() {
+		if err := img.Flatten(&vips.FlattenOptions{Background: []float64{0, 0, 0}}); err != nil {
+			return nil, fmt.Errorf("vips flatten: %w", err)
+		}
+	}
+
+	bands := img.Bands()
+	switch {
+	case bands > 3:
+		if err := img.ExtractBand(0, &vips.ExtractBandOptions{N: 3}); err != nil {
+			return nil, fmt.Errorf("vips extract band: %w", err)
+		}
+		bands = img.Bands()
+	case bands < 3:
+		// Expand to RGB by joining bands with themselves.
+		bandImages := make([]*vips.Image, 0, 3)
+		for bands < 3 {
+			dup, dupErr := img.Copy(nil)
+			if dupErr != nil {
+				for _, im := range bandImages {
+					im.Close()
+				}
+				return nil, fmt.Errorf("vips duplicate band: %w", dupErr)
+			}
+			bandImages = append(bandImages, dup)
+			bands++
+		}
+		joined, joinErr := vips.NewBandjoin(append([]*vips.Image{img}, bandImages...))
+		for _, im := range bandImages {
+			im.Close()
+		}
+		if joinErr != nil {
+			return nil, fmt.Errorf("vips bandjoin: %w", joinErr)
+		}
+		old := img
+		img = joined
+		old.Close()
+		bands = img.Bands()
+	}
+
+	if bands != 3 {
+		return nil, fmt.Errorf("unexpected band count %d", bands)
+	}
+
+	if img.BandFormat() != vips.BandFormatUchar {
+		if err := img.Cast(vips.BandFormatUchar, nil); err != nil {
+			return nil, fmt.Errorf("vips cast: %w", err)
+		}
+	}
+
+	width := img.Width()
+	height := img.Height()
+	if width != S || height != S {
+		return nil, fmt.Errorf("unexpected thumbnail size %dx%d (expected %d)", width, height, S)
+	}
+
+	raw, err := img.RawsaveBuffer(nil)
+	if err != nil {
+		return nil, fmt.Errorf("vips rawsave: %w", err)
+	}
+	if len(raw) != 3*S*S {
+		return nil, fmt.Errorf("unexpected raw buffer length %d (expected %d)", len(raw), 3*S*S)
+	}
 
 	pix := make([]float32, 3*S*S)
 	for y := 0; y < S; y++ {
+		rowOffset := y * S
 		for x := 0; x < S; x++ {
-			r, g, b, _ := img.At(x, y).RGBA()
-			i := y*S + x
-			pix[i] = (float32(r>>8)/255 - .5) / .5
-			pix[S*S+i] = (float32(g>>8)/255 - .5) / .5
-			pix[2*S*S+i] = (float32(b>>8)/255 - .5) / .5
+			idx := rowOffset + x
+			base := idx * 3
+			pix[idx] = (float32(raw[base])/255 - .5) / .5
+			pix[S*S+idx] = (float32(raw[base+1])/255 - .5) / .5
+			pix[2*S*S+idx] = (float32(raw[base+2])/255 - .5) / .5
 		}
 	}
 

--- a/internal/workers/embedworker/image_embed_worker.go
+++ b/internal/workers/embedworker/image_embed_worker.go
@@ -12,6 +12,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"time"
 
 	"era/booru/ent"
 	"era/booru/internal/config"
@@ -94,6 +95,8 @@ func (w *ImageEmbedWorker) videoEmbedding(ctx context.Context, bucket, key strin
 	if w.Cfg == nil {
 		return nil, fmt.Errorf("missing worker configuration")
 	}
+
+	startTime := time.Now()
 
 	duration := 0
 	if media.Duration != nil && *media.Duration > 0 {
@@ -201,6 +204,10 @@ func (w *ImageEmbedWorker) videoEmbedding(ctx context.Context, bucket, key strin
 	}
 
 	avg, err := averageVectors(vectors)
+
+	elapsed := time.Since(startTime).Milliseconds()
+	log.Printf("Video embedding for %s: extracted %d frames, %d errors, took %d ms", key, len(vectors), extractErrors, elapsed)
+
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
- replace the vision embedding pipeline with libvips (via vipsgen) so ONNX inputs are generated from raw image buffers
- read still images as raw bytes and parallelize video frame extraction/embedding to speed up media processing
- add the vipsgen dependency needed for libvips-backed preprocessing

## Testing
- `GOTOOLCHAIN=go1.25.0 go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68db9c4e15c4832099549e15a7fedf92