### PR TITLE
Batch video frame embeddings for faster video processing

### DIFF
--- a/internal/embeddings/dummy.go
+++ b/internal/embeddings/dummy.go
@@ -12,6 +12,10 @@ func VisionEmbedding([]byte) ([]float32, error) {
 	return nil, nil
 }
 
+func VisionEmbeddingBatch([][]byte) ([][]float32, error) {
+	return nil, nil
+}
+
 func TextEmbedding(any interface{}) ([]float32, error) {
 	return nil, nil
 }


### PR DESCRIPTION
## Summary
- add a batched VisionEmbeddingBatch API so the ONNX vision model can process multiple frames per invocation
- update the video embedding worker to extract frames concurrently but embed them in batches before averaging
- extend the dummy embeddings build with a matching batch stub for non-embeddings builds

## Testing
- go test ./...
- go vet ./...


------
https://chatgpt.com/codex/tasks/task_e_68dce86df79083208e5ee5e1bf7d6b33