### PR TITLE
Enable GPU support for embed worker

### DIFF
--- a/cmd/image_embed_worker/Dockerfile
+++ b/cmd/image_embed_worker/Dockerfile
@@ -2,6 +2,7 @@
 FROM golang:1.25-bookworm AS builder
 
 ARG ONNXRUNTIME_VERSION=1.22.0
+ARG ONNXRUNTIME_PACKAGE=onnxruntime-linux-x64-gpu
 ARG LIBVIPS_VERSION=8.17.2
 
 # CGO + libvips build deps (no pip/gettext)
@@ -37,12 +38,12 @@ ENV PKG_CONFIG_PATH="/opt/libvips/lib/pkgconfig:/opt/libvips/lib/x86_64-linux-gn
 ENV LD_LIBRARY_PATH="/opt/libvips/lib:/opt/libvips/lib/x86_64-linux-gnu:${LD_LIBRARY_PATH}"
 RUN pkg-config --modversion vips && pkg-config --cflags --libs vips
 
-# ---- ONNX Runtime (CPU) in builder; copy later to runtime ----
-RUN wget -q https://github.com/microsoft/onnxruntime/releases/download/v${ONNXRUNTIME_VERSION}/onnxruntime-linux-x64-${ONNXRUNTIME_VERSION}.tgz \
-    && tar -xzf onnxruntime-linux-x64-${ONNXRUNTIME_VERSION}.tgz \
+# ---- ONNX Runtime (GPU enabled) in builder; copy later to runtime ----
+RUN wget -q https://github.com/microsoft/onnxruntime/releases/download/v${ONNXRUNTIME_VERSION}/${ONNXRUNTIME_PACKAGE}-${ONNXRUNTIME_VERSION}.tgz \
+    && tar -xzf ${ONNXRUNTIME_PACKAGE}-${ONNXRUNTIME_VERSION}.tgz \
     && mkdir -p /opt/onnxruntime \
-    && cp -r onnxruntime-linux-x64-${ONNXRUNTIME_VERSION}/* /opt/onnxruntime/ \
-    && rm -rf onnxruntime-linux-x64-${ONNXRUNTIME_VERSION}*
+    && cp -r ${ONNXRUNTIME_PACKAGE}-${ONNXRUNTIME_VERSION}/* /opt/onnxruntime/ \
+    && rm -rf ${ONNXRUNTIME_PACKAGE}-${ONNXRUNTIME_VERSION}*
 
 # Create the alias the Go wrapper expects
 RUN ln -sf /opt/onnxruntime/lib/libonnxruntime.so.${ONNXRUNTIME_VERSION} /opt/onnxruntime/lib/onnxruntime.so
@@ -71,12 +72,22 @@ RUN find /opt/libvips -type f -name "*.so*" -exec sh -c 'for f; do strip --strip
 # ---------- runtime stage ----------
 FROM debian:bookworm-slim
 
-# Runtime libs (match codecs enabled above)
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates ffmpeg libc6 libgcc-s1 libstdc++6 \
-    liborc-0.4-0 libjpeg62-turbo libpng16-16 libtiff6 \
-    libwebp7 libwebpdemux2 libwebpmux3 libexif12 \
- && rm -rf /var/lib/apt/lists/*
+# Runtime libs (match codecs enabled above) + CUDA runtime for ONNX Runtime GPU
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        ca-certificates ffmpeg libc6 libgcc-s1 libstdc++6 \
+        liborc-0.4-0 libjpeg62-turbo libpng16-16 libtiff6 \
+        libwebp7 libwebpdemux2 libwebpmux3 libexif12 wget; \
+    wget -q https://developer.download.nvidia.com/compute/cuda/repos/debian12/x86_64/cuda-keyring_1.1-1_all.deb; \
+    dpkg -i cuda-keyring_1.1-1_all.deb; \
+    rm cuda-keyring_1.1-1_all.deb; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        cuda-compat-12-4 \
+        cuda-libraries-12-4 \
+        libcudnn9-cuda-12; \
+    rm -rf /var/lib/apt/lists/*
 
 # Copy only libvips runtime bits (no headers)
 COPY --from=builder /opt/libvips/lib /opt/libvips/lib
@@ -86,7 +97,7 @@ COPY --from=builder /opt/libvips/share /opt/libvips/share
 COPY --from=builder /opt/onnxruntime /opt/onnxruntime
 
 # Runtime linker paths
-ENV LD_LIBRARY_PATH="/opt/onnxruntime/lib:/opt/libvips/lib:/opt/libvips/lib/x86_64-linux-gnu:${LD_LIBRARY_PATH}"
+ENV LD_LIBRARY_PATH="/opt/onnxruntime/lib:/opt/libvips/lib:/opt/libvips/lib/x86_64-linux-gnu:/usr/local/cuda/lib64:/usr/local/cuda-12.4/lib64:${LD_LIBRARY_PATH}"
 
 # App binary
 COPY --from=builder /bin/image_embed_worker /usr/local/bin/image_embed_worker

--- a/docker-compose.pull.yml
+++ b/docker-compose.pull.yml
@@ -13,3 +13,13 @@ services:
   image-embed-worker:
     image: ghcr.io/era-things/erabooru-embed-worker:latest
     build: null
+    environment:
+      - NVIDIA_VISIBLE_DEVICES=${NVIDIA_VISIBLE_DEVICES:-all}
+      - NVIDIA_DRIVER_CAPABILITIES=${NVIDIA_DRIVER_CAPABILITIES:-compute,utility}
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -127,6 +127,8 @@ services:
     environment:
       - POSTGRES_DSN=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}?sslmode=disable
       - MODEL_CACHE_DIR=/cache/models
+      - NVIDIA_VISIBLE_DEVICES=${NVIDIA_VISIBLE_DEVICES:-all}
+      - NVIDIA_DRIVER_CAPABILITIES=${NVIDIA_DRIVER_CAPABILITIES:-compute,utility}
     volumes:
       - model-cache:/cache
     depends_on:
@@ -136,3 +138,10 @@ services:
         condition: service_started
       app:
         condition: service_healthy
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]


### PR DESCRIPTION
## Summary
- build the image embed worker container with the GPU-enabled ONNX Runtime and CUDA runtime libraries
- request GPUs for the embed worker in docker-compose configurations and expose NVIDIA runtime environment variables

## Testing
- not run (not required)


------
https://chatgpt.com/codex/tasks/task_e_68dcf4aeaedc83209627bdcf06706a3c