### PR TITLE
Switch video embedding to raw RGB frames

### DIFF
--- a/internal/embeddings/dummy.go
+++ b/internal/embeddings/dummy.go
@@ -12,6 +12,10 @@ func VisionEmbedding([]byte) ([]float32, error) {
 	return nil, nil
 }
 
+func VisionEmbeddingRGB24([]byte) ([]float32, error) {
+	return nil, nil
+}
+
 func TextEmbedding(any interface{}) ([]float32, error) {
 	return nil, nil
 }
@@ -27,6 +31,8 @@ func EnsureModel(ctx context.Context, opts ModelOptions) (string, error) {
 func Load(dir string) error {
 	return nil
 }
+
+func InputSpatialSize() int { return 0 }
 
 // Add any types referenced in main.go or workers
 type ModelOptions struct{}

--- a/internal/embeddings/vision.go
+++ b/internal/embeddings/vision.go
@@ -66,6 +66,14 @@ func l2(v []float32) {
 	}
 }
 
+func VisionEmbeddingRGB24(buf []byte) ([]float32, error) {
+	S := InputSpatialSize()
+	if S <= 0 {
+		return nil, fmt.Errorf("invalid vision input size %d", S)
+	}
+	return visionEmbeddingRGB24WithSize(buf, S)
+}
+
 func visionEmbeddingWithSize(buf []byte, S int) ([]float32, error) {
 	if S <= 0 {
 		return nil, fmt.Errorf("invalid vision input size %d", S)
@@ -172,20 +180,52 @@ func visionEmbeddingWithSize(buf []byte, S int) ([]float32, error) {
 	if err != nil {
 		return nil, fmt.Errorf("vips rawsave: %w", err)
 	}
-	if len(raw) != 3*S*S {
-		return nil, fmt.Errorf("unexpected raw buffer length %d (expected %d)", len(raw), 3*S*S)
+
+	return visionEmbeddingRGB24WithSize(raw, S)
+}
+
+func visionEmbeddingRGB24WithSize(raw []byte, S int) ([]float32, error) {
+	pix, err := normalizeRGB24(raw, S)
+	if err != nil {
+		return nil, err
+	}
+	return runVisionModel(pix, S)
+}
+
+func normalizeRGB24(raw []byte, S int) ([]float32, error) {
+	if S <= 0 {
+		return nil, fmt.Errorf("invalid vision input size %d", S)
+	}
+	expected := 3 * S * S
+	if len(raw) != expected {
+		return nil, fmt.Errorf("unexpected raw buffer length %d (expected %d)", len(raw), expected)
 	}
 
-	pix := make([]float32, 3*S*S)
+	pix := make([]float32, expected)
+	planeSize := S * S
 	for y := 0; y < S; y++ {
 		rowOffset := y * S
 		for x := 0; x < S; x++ {
 			idx := rowOffset + x
 			base := idx * 3
-			pix[idx] = (float32(raw[base])/255 - .5) / .5
-			pix[S*S+idx] = (float32(raw[base+1])/255 - .5) / .5
-			pix[2*S*S+idx] = (float32(raw[base+2])/255 - .5) / .5
+			normR := (float32(raw[base])/255 - .5) / .5
+			normG := (float32(raw[base+1])/255 - .5) / .5
+			normB := (float32(raw[base+2])/255 - .5) / .5
+			pix[idx] = normR
+			pix[planeSize+idx] = normG
+			pix[2*planeSize+idx] = normB
 		}
+	}
+
+	return pix, nil
+}
+
+func runVisionModel(pix []float32, S int) ([]float32, error) {
+	if S <= 0 {
+		return nil, fmt.Errorf("invalid vision input size %d", S)
+	}
+	if len(pix) != 3*S*S {
+		return nil, fmt.Errorf("unexpected tensor length %d (expected %d)", len(pix), 3*S*S)
 	}
 
 	in, err := ort.NewTensor[float32](ort.NewShape(1, 3, int64(S), int64(S)), pix)
@@ -194,8 +234,13 @@ func visionEmbeddingWithSize(buf []byte, S int) ([]float32, error) {
 	}
 	defer in.Destroy()
 
+	sess := Session()
+	if sess == nil {
+		return nil, fmt.Errorf("vision session not initialised")
+	}
+
 	outputs := []ort.Value{nil}
-	if err := Session().Run(
+	if err := sess.Run(
 		[]ort.Value{in},
 		outputs,
 	); err != nil {

--- a/internal/embeddings/vision_rgb_test.go
+++ b/internal/embeddings/vision_rgb_test.go
@@ -1,0 +1,70 @@
+//go:build embeddings
+
+package embed
+
+import "testing"
+
+func TestNormalizeRGB24(t *testing.T) {
+	const S = 2
+	raw := []byte{
+		0, 127, 255,
+		64, 128, 192,
+		255, 255, 255,
+		10, 20, 30,
+	}
+
+	tensor, err := normalizeRGB24(raw, S)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expectedLen := 3 * S * S
+	if len(tensor) != expectedLen {
+		t.Fatalf("unexpected tensor length %d", len(tensor))
+	}
+
+	norm := func(v byte) float32 {
+		return (float32(v)/255 - .5) / .5
+	}
+
+	expectedR := []float32{norm(0), norm(64), norm(255), norm(10)}
+	expectedG := []float32{norm(127), norm(128), norm(255), norm(20)}
+	expectedB := []float32{norm(255), norm(192), norm(255), norm(30)}
+
+	for i, want := range expectedR {
+		if got := tensor[i]; !almostEqual(got, want) {
+			t.Fatalf("unexpected R channel value at %d: got %f, want %f", i, got, want)
+		}
+	}
+	for i, want := range expectedG {
+		idx := S*S + i
+		if got := tensor[idx]; !almostEqual(got, want) {
+			t.Fatalf("unexpected G channel value at %d: got %f, want %f", i, got, want)
+		}
+	}
+	for i, want := range expectedB {
+		idx := 2*S*S + i
+		if got := tensor[idx]; !almostEqual(got, want) {
+			t.Fatalf("unexpected B channel value at %d: got %f, want %f", i, got, want)
+		}
+	}
+}
+
+func TestNormalizeRGB24InvalidLength(t *testing.T) {
+	const S = 2
+	_, err := normalizeRGB24(make([]byte, 3*S*S-1), S)
+	if err == nil {
+		t.Fatalf("expected error for short buffer")
+	}
+}
+
+func almostEqual(a, b float32) bool {
+	if a == b {
+		return true
+	}
+	diff := a - b
+	if diff < 0 {
+		diff = -diff
+	}
+	return diff < 1e-4
+}


### PR DESCRIPTION
## Summary
- stream ffmpeg video frames as padded rgb24 rawvideo at the model's spatial size
- add a raw rgb24 embedding helper that reuses the shared ONNX execution path with unit tests
- update non-embeddings stubs to match the new API surface

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68dd34b811208320977fd11e4725e842