### PR TITLE
Prevent duplicate index jobs and add queue metrics

### DIFF
--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -69,6 +69,8 @@ func getConfigForClientType(clientType ClientType, workers *river.Workers) *rive
 
 // Enqueue inserts a job into the default queue.
 func Enqueue(ctx context.Context, c *river.Client[pgx.Tx], args river.JobArgs) error {
+	opts := &river.InsertOpts{}
+
 	var (
 		queueName   string
 		priority    int
@@ -80,6 +82,7 @@ func Enqueue(ctx context.Context, c *river.Client[pgx.Tx], args river.JobArgs) e
 		queueName = "process" // Goes to media worker
 	case IndexArgs:
 		queueName = "index" // Goes to server
+		opts.UniqueOpts = river.UniqueOpts{ByArgs: true}
 	case EmbedArgs:
 		queueName = "embed" // Goes to image embed worker
 		priority = 2        // lower priority than search embeddings
@@ -92,7 +95,6 @@ func Enqueue(ctx context.Context, c *river.Client[pgx.Tx], args river.JobArgs) e
 		queueName = "" // Default queue
 	}
 
-	opts := &river.InsertOpts{}
 	if queueName != "" {
 		opts.Queue = queueName
 	}

--- a/internal/workers/indexworker/index_worker.go
+++ b/internal/workers/indexworker/index_worker.go
@@ -2,6 +2,7 @@ package indexworker
 
 import (
 	"context"
+	"fmt"
 	"log"
 
 	"era/booru/ent"
@@ -32,11 +33,21 @@ func (w *IndexWorker) Work(ctx context.Context, job *river.Job[queue.IndexArgs])
 		Only(ctx)
 	if ent.IsNotFound(err) {
 		log.Printf("Media with ID %s not found, deleting from index", job.Args.ID)
-		return search.DeleteMedia(job.Args.ID)
+		if err := search.DeleteMedia(job.Args.ID); err != nil {
+			return err
+		}
+		logIndexQueueDepth(ctx, fmt.Sprintf("Deleted stale index entry for media %s (job %d)", job.Args.ID, job.ID))
+		return nil
 	}
 	if err != nil {
 		log.Printf("Error retrieving media with ID %s: %v", job.Args.ID, err)
 		return err
 	}
-	return search.IndexMedia(mobj)
+	if err := search.IndexMedia(mobj); err != nil {
+		return err
+	}
+
+	logIndexQueueDepth(ctx, fmt.Sprintf("Indexed media %s (job %d)", job.Args.ID, job.ID))
+
+	return nil
 }

--- a/internal/workers/indexworker/queue_metrics.go
+++ b/internal/workers/indexworker/queue_metrics.go
@@ -1,0 +1,64 @@
+package indexworker
+
+import (
+	"context"
+	"errors"
+	"log"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/riverqueue/river"
+	"github.com/riverqueue/river/rivertype"
+)
+
+const (
+	indexQueueName     = "index"
+	indexQueuePageSize = 512
+)
+
+var indexQueueActiveStates = []rivertype.JobState{
+	rivertype.JobStateAvailable,
+	rivertype.JobStatePending,
+	rivertype.JobStateRetryable,
+	rivertype.JobStateRunning,
+	rivertype.JobStateScheduled,
+}
+
+func logIndexQueueDepth(ctx context.Context, message string) {
+	remaining, err := countActiveIndexJobs(ctx)
+	if err != nil {
+		log.Printf("%s; unable to determine remaining index jobs: %v", message, err)
+		return
+	}
+
+	log.Printf("%s (%d index jobs remaining)", message, remaining)
+}
+
+func countActiveIndexJobs(ctx context.Context) (int, error) {
+	client := river.ClientFromContext[pgx.Tx](ctx)
+	if client == nil {
+		return 0, errors.New("river client missing from context")
+	}
+
+	params := river.NewJobListParams().
+		Queues(indexQueueName).
+		States(indexQueueActiveStates...).
+		OrderBy(river.JobListOrderByID, river.SortOrderAsc).
+		First(indexQueuePageSize)
+
+	total := 0
+	for {
+		res, err := client.JobList(ctx, params)
+		if err != nil {
+			return 0, err
+		}
+
+		total += len(res.Jobs)
+		if res.LastCursor == nil {
+			break
+		}
+
+		params = params.After(res.LastCursor)
+	}
+
+	return total, nil
+}


### PR DESCRIPTION
## Summary
- ensure index jobs use River's unique-by-args option so duplicate jobs for the same media are skipped
- add queue depth logging for index jobs to mirror the embed worker
- log remaining index jobs after each worker run, including stale deletions

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e566d4be4483209ca7a507f8429d68